### PR TITLE
Fix /mute not accepting a reason

### DIFF
--- a/gbans_example.yml
+++ b/gbans_example.yml
@@ -75,6 +75,8 @@ discord:
   public_log_channel_id: "000000000000000000"
   # Commands all start with this character
   prefix: "!"
+  # Right click on the server -> copy id
+  guild_id:
 
 logging:
   # Set the debug log level

--- a/internal/discord/bot_commands.go
+++ b/internal/discord/bot_commands.go
@@ -98,6 +98,7 @@ func (b *discord) botRegisterSlashCommands() error {
 			Options: []*discordgo.ApplicationCommandOption{
 				optUserID,
 				optDuration,
+				optReason,
 			},
 		},
 		{

--- a/internal/discord/bot_handlers.go
+++ b/internal/discord/bot_handlers.go
@@ -284,6 +284,10 @@ func (b *discord) onCheck(ctx context.Context, _ *discordgo.Session, m *discordg
 		banned = ban.Ban.BanType == model.Banned
 		muted = ban.Ban.BanType == model.NoComm
 		reason = ban.Ban.ReasonText
+		if len(reason) == 0 {
+			// in case a ban without a reason ever makes its way here, we make sure that Discord doesn't shit itself
+			reason = "none"
+		}
 		expiry = ban.Ban.ValidUntil
 		createdAt = ban.Ban.CreatedOn.Format(time.RFC3339)
 		if ban.Ban.AuthorID > 0 {

--- a/internal/store/db.go
+++ b/internal/store/db.go
@@ -138,7 +138,7 @@ func (db *pgStore) truncateTable(ctx context.Context, table tableName) error {
 	return nil
 }
 
-// dbErr is used to wrap common database errors in own own error types
+// dbErr is used to wrap common database errors in own error types
 func dbErr(err error) error {
 	if err == nil {
 		return err


### PR DESCRIPTION
Since having reason as `nil` made Discord complain when /check was used
due to it not accepting an empty string as an embed message parameter,
this also adds a check for blank reasons for previous mutes and bans
made without a specified reason.