### PR TITLE
Add reason to mutes (second attempt)

### DIFF
--- a/gbans_example.yml
+++ b/gbans_example.yml
@@ -64,6 +64,8 @@ discord:
   public_log_channel_id: "000000000000000000"
   # Commands all start with this character
   prefix: "!"
+  # Right click on the server -> copy id
+  guild_id:
 
 logging:
   # Set the debug log level

--- a/internal/app/discord_commands.go
+++ b/internal/app/discord_commands.go
@@ -101,6 +101,7 @@ func (b *discord) botRegisterSlashCommands() error {
 			Options: []*discordgo.ApplicationCommandOption{
 				optUserID,
 				optDuration,
+				optReason,
 			},
 		},
 		{

--- a/internal/app/discord_handlers.go
+++ b/internal/app/discord_handlers.go
@@ -318,6 +318,10 @@ func (b *discord) onCheck(ctx context.Context, _ *discordgo.Session, m *discordg
 		banned = ban.Ban.BanType == model.Banned
 		muted = ban.Ban.BanType == model.NoComm
 		reason = ban.Ban.ReasonText
+		if len(reason) == 0 {
+			// in case a ban without a reason ever makes its way here, we make sure that Discord doesn't shit itself
+			reason = "none"
+		}
 		expiry = ban.Ban.ValidUntil
 		createdAt = ban.Ban.CreatedOn.Format(time.RFC3339)
 		if ban.Ban.AuthorID > 0 {


### PR DESCRIPTION
Since having reason as `nil` made Discord complain when /check was used
due to it not accepting an empty string as an embed message parameter,
this also adds a check for blank reasons for previous mutes and bans
made without a specified reason.