### PR TITLE
chore: update Dockerfile to reduce the image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # node-sass does not compile with node:16 yet
 FROM node:18-alpine as frontend
 WORKDIR /build
-RUN apk add python3 make g++
+RUN apk add --no-cache python3 make g++
 COPY frontend/package.json frontend/package.json
 COPY frontend/yarn.lock yarn.lock
 COPY frontend frontend
@@ -11,7 +11,7 @@ RUN yarn build
 
 FROM golang:1.19-alpine as build
 WORKDIR /build
-RUN apk add make git gcc libc-dev
+RUN apk add --no-cache make git gcc libc-dev
 COPY go.mod go.sum Makefile main.go ./
 RUN go mod download
 COPY pkg pkg
@@ -22,7 +22,7 @@ FROM alpine:latest
 LABEL maintainer="Leigh MacDonald <leigh.macdonald@gmail.com>"
 LABEL org.opencontainers.image.source="https://github.com/leighmacdonald/gbans"
 EXPOSE 6006
-RUN apk add dumb-init
+RUN apk add --no-cache dumb-init
 WORKDIR /app
 VOLUME ["/app/.cache"]
 COPY --from=frontend /build/dist ./dist/


### PR DESCRIPTION
Hi there,

I've made a small improvement to the Dockerfile that I think could help optimize the image size. It is not much but still :) I hope you will find it useful.

The change I made:
* I added `--no-cache` flag to `apk add` to ensure that no useless information is kept inside the Docker image.


Impact on the image size:
* Image size before repair: 40.45 MB
* Image size after repair: 37.99 MB
* Difference: 2.46 MB (6.09%)


Thanks,