### PR TITLE
Use ip for steam:// protocol handler

### DIFF
--- a/frontend/src/api/server.ts
+++ b/frontend/src/api/server.ts
@@ -4,6 +4,7 @@ export interface BaseServer {
     server_id: number;
     host: string;
     port: number;
+    ip: string;
     name: string;
     name_short: string;
     region: string;

--- a/frontend/src/component/ServerList.tsx
+++ b/frontend/src/component/ServerList.tsx
@@ -177,7 +177,7 @@ export const ServerList = () => {
                             return (
                                 <Button
                                     component={Link}
-                                    href={`steam://connect/${serverState.host}:${serverState.port}`}
+                                    href={`steam://connect/${serverState.ip}:${serverState.port}`}
                                     variant={'contained'}
                                     sx={{ minWidth: 100 }}
                                 >

--- a/internal/app/http_api.go
+++ b/internal/app/http_api.go
@@ -941,6 +941,7 @@ func onAPIGetServerStates(app *App) gin.HandlerFunc {
 			servers = append(servers, baseServer{
 				Host:       srv.Host,
 				Port:       srv.Port,
+				IP:         srv.IP,
 				Name:       srv.Name,
 				NameShort:  srv.NameShort,
 				Region:     srv.Region,


### PR DESCRIPTION
Recent steam client removes the ability to use fqdn for protocol handlers `steam://connect/`.

This allows the use of either form in the backend, but automatically resolves the dns name for when used in a protocol handler link.