### PR TITLE
Docker Release Build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,17 +6,8 @@ COPY frontend/package.json frontend/package.json
 COPY frontend/yarn.lock yarn.lock
 COPY frontend frontend
 WORKDIR /build/frontend
-RUN yarn
+RUN yarn install --frozen-lockfile
 RUN yarn build
-
-FROM golang:1.21-alpine as build
-WORKDIR /build
-RUN apk add --no-cache make git gcc libc-dev
-COPY go.mod go.sum Makefile main.go default.pgo ./
-RUN go mod download
-COPY pkg pkg
-COPY internal internal
-RUN make build
 
 FROM alpine:latest
 
@@ -33,6 +24,6 @@ RUN apk add --no-cache dumb-init
 WORKDIR /app
 VOLUME ["/app/.cache"]
 COPY --from=frontend /build/dist ./dist/
-COPY --from=build /build/build/linux64/gbans .
+COPY /build/gbans_linux_amd64_v1/gbans .
 ENTRYPOINT ["dumb-init", "--"]
 CMD ["./gbans", "serve"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ FROM alpine:latest
 
 LABEL maintainer="Leigh MacDonald <leigh.macdonald@gmail.com>"
 LABEL org.opencontainers.image.source="https://github.com/leighmacdonald/gbans"
-LABEL org.opencontainers.image.version="v0.3.2"
+LABEL org.opencontainers.image.version="v0.4.1"
 LABEL org.opencontainers.image.licenses="MIT"
 LABEL org.opencontainers.image.description="Centralized community backend for Team Fortress 2"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,6 @@ RUN apk add --no-cache dumb-init
 WORKDIR /app
 VOLUME ["/app/.cache"]
 COPY --from=frontend /build/dist ./dist/
-COPY /build/gbans_linux_amd64_v1/gbans .
+COPY ./build/gbans_linux_amd64_v1/gbans .
 ENTRYPOINT ["dumb-init", "--"]
 CMD ["./gbans", "serve"]


### PR DESCRIPTION
Emedded the production build into the container. This is done because we inject the build context into the binary on build, which does not currently happen within the docker 