### PR TITLE
Improve Group Bans & Add Deep Steam Bans

### DIFF
--- a/frontend/src/api/bans.ts
+++ b/frontend/src/api/bans.ts
@@ -245,22 +245,29 @@ export interface BanBasePayload {
     target_id: string;
     duration: string;
     ban_type: BanType;
-    reason: number;
-    reason_text: string;
     note: string;
 }
 
-export interface BanPayloadSteam extends BanBasePayload {
+interface BanReasonPayload {
+    reason: number;
+    reason_text: string;
+}
+
+export interface BanPayloadSteam extends BanBasePayload, BanReasonPayload {
     report_id?: number;
     include_friends: boolean;
 }
 
-export interface BanPayloadCIDR extends BanBasePayload {
+export interface BanPayloadCIDR extends BanBasePayload, BanReasonPayload {
     cidr: string;
 }
 
-export interface BanPayloadASN extends BanBasePayload {
+export interface BanPayloadASN extends BanBasePayload, BanReasonPayload {
     as_num: number;
+}
+
+export interface BanPayloadGroup extends BanBasePayload {
+    group_id: string;
 }
 
 export const apiGetBansSteam = async (
@@ -370,8 +377,8 @@ export const apiCreateBanASN = async (p: BanPayloadASN) =>
         p
     );
 
-export const apiCreateBanGroup = async (p: BanBasePayload) =>
-    await apiCall<IAPIBanGroupRecord, BanBasePayload>(
+export const apiCreateBanGroup = async (p: BanPayloadGroup) =>
+    await apiCall<IAPIBanGroupRecord, BanPayloadGroup>(
         `/api/bans/group/create`,
         'POST',
         p

--- a/frontend/src/api/bans.ts
+++ b/frontend/src/api/bans.ts
@@ -177,6 +177,7 @@ export interface IAPIBanRecord extends BanBase {
     ban_id: number;
     report_id: number;
     ban_type: BanType;
+    include_friends: boolean;
 }
 
 export interface SimplePerson {
@@ -251,6 +252,7 @@ export interface BanBasePayload {
 
 export interface BanPayloadSteam extends BanBasePayload {
     report_id?: number;
+    include_friends: boolean;
 }
 
 export interface BanPayloadCIDR extends BanBasePayload {
@@ -301,7 +303,8 @@ export const apiGetBansSteam = async (
                 appeal_state: b.ban.appeal_state,
                 created_on: b.ban.created_on,
                 updated_on: b.ban.updated_on,
-                valid_until: b.ban.valid_until
+                valid_until: b.ban.valid_until,
+                include_friends: b.ban.include_friends
             };
         })
         .map(applyDateTime);

--- a/frontend/src/component/BanASNModal.tsx
+++ b/frontend/src/component/BanASNModal.tsx
@@ -37,12 +37,12 @@ export interface BanASNModalProps {
 }
 
 interface BanASNFormValues extends SteamIDInputValue {
-    asNum: number;
-    banType: BanType;
+    as_num: number;
+    ban_type: BanType;
     reason: BanReason;
-    reasonText: string;
+    reason_text: string;
     duration: Duration;
-    durationCustom: string;
+    duration_custom: string;
     note: string;
 }
 
@@ -62,14 +62,14 @@ export const BanASNModal = ({ open, setOpen }: BanASNModalProps) => {
 
     const formik = useFormik<BanASNFormValues>({
         initialValues: {
-            banType: BanType.NoComm,
+            ban_type: BanType.NoComm,
             duration: Duration.dur2w,
-            durationCustom: '',
+            duration_custom: '',
             note: '',
             reason: BanReason.Cheating,
             steam_id: '',
-            reasonText: '',
-            asNum: 0
+            reason_text: '',
+            as_num: 0
         },
         validateOnBlur: true,
         validateOnChange: false,
@@ -81,12 +81,12 @@ export const BanASNModal = ({ open, setOpen }: BanASNModalProps) => {
             try {
                 await apiCreateBanASN({
                     note: values.note,
-                    ban_type: values.banType,
+                    ban_type: values.ban_type,
                     duration: values.duration,
                     reason: values.reason,
-                    reason_text: values.reasonText,
+                    reason_text: values.reason_text,
                     target_id: values.steam_id,
-                    as_num: values.asNum
+                    as_num: values.as_num
                 });
                 sendFlash('success', 'Ban created successfully');
             } catch (e) {

--- a/frontend/src/component/BanCIDRModal.tsx
+++ b/frontend/src/component/BanCIDRModal.tsx
@@ -41,11 +41,11 @@ export interface BanCIDRModalProps {
 
 interface BanCIDRFormValues extends SteamIDInputValue {
     cidr: string;
-    banType: BanType;
+    ban_type: BanType;
     reason: BanReason;
-    reasonText: string;
+    reason_text: string;
     duration: Duration;
-    durationCustom: string;
+    duration_custom: string;
     note: string;
 }
 
@@ -65,13 +65,13 @@ export const BanCIDRModal = ({ open, setOpen }: BanCIDRModalProps) => {
 
     const formik = useFormik<BanCIDRFormValues>({
         initialValues: {
-            banType: BanType.NoComm,
+            ban_type: BanType.NoComm,
             duration: Duration.dur2w,
-            durationCustom: '',
+            duration_custom: '',
             note: '',
             reason: BanReason.Cheating,
             steam_id: '',
-            reasonText: '',
+            reason_text: '',
             cidr: ''
         },
         validateOnBlur: true,
@@ -84,10 +84,10 @@ export const BanCIDRModal = ({ open, setOpen }: BanCIDRModalProps) => {
             try {
                 await apiCreateBanCIDR({
                     note: values.note,
-                    ban_type: values.banType,
+                    ban_type: values.ban_type,
                     duration: values.duration,
                     reason: values.reason,
-                    reason_text: values.reasonText,
+                    reason_text: values.reason_text,
                     target_id: values.steam_id,
                     cidr: values.cidr
                 });
@@ -118,6 +118,11 @@ export const BanCIDRModal = ({ open, setOpen }: BanCIDRModalProps) => {
 
                 <DialogContent>
                     <Stack spacing={2}>
+                        <SteamIdField
+                            formik={formik}
+                            fullWidth
+                            isReadOnly={false}
+                        />
                         <SteamIdField
                             formik={formik}
                             fullWidth

--- a/frontend/src/component/BanGroupModal.tsx
+++ b/frontend/src/component/BanGroupModal.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import Stack from '@mui/material/Stack';
 import {
     apiCreateBanGroup,
-    BanReason,
     BanType,
     Duration,
     IAPIBanGroupRecord
@@ -15,11 +14,6 @@ import { useFormik } from 'formik';
 import * as yup from 'yup';
 import { Dialog, DialogContent, DialogTitle } from '@mui/material';
 import GavelIcon from '@mui/icons-material/Gavel';
-import { BanTypeField, BanTypeFieldValidator } from './formik/BanTypeField';
-import {
-    BanReasonField,
-    BanReasonFieldValidator
-} from './formik/BanReasonField';
 import { DurationField, DurationFieldValidator } from './formik/DurationField';
 import {
     DurationCustomField,
@@ -28,31 +22,22 @@ import {
 import { NoteField, NoteFieldValidator } from './formik/NoteField';
 import { ModalButtons } from './formik/ModalButtons';
 import { GroupIdField, GroupIdFieldValidator } from './formik/GroupIdField';
-import {
-    BanReasonTextField,
-    BanReasonTextFieldValidator
-} from './formik/BanReasonTextField';
+import { SteamIdField, steamIdValidator } from './formik/SteamIdField';
 
 export interface BanGroupModalProps
-    extends ConfirmationModalProps<IAPIBanGroupRecord> {
-    asnNum?: number;
-}
+    extends ConfirmationModalProps<IAPIBanGroupRecord> {}
 
 interface BanGroupFormValues {
-    groupId: string;
-    banType: BanType;
-    reason: BanReason;
-    reasonText: string;
+    steam_id: string;
+    group_id: string;
     duration: Duration;
-    durationCustom: string;
+    duration_custom: string;
     note: string;
 }
 
 const validationSchema = yup.object({
+    steam_id: steamIdValidator,
     groupId: GroupIdFieldValidator,
-    banType: BanTypeFieldValidator,
-    reason: BanReasonFieldValidator,
-    reasonText: BanReasonTextFieldValidator,
     duration: DurationFieldValidator,
     durationCustom: DurationCustomFieldValidator,
     note: NoteFieldValidator
@@ -63,27 +48,24 @@ export const BanGroupModal = ({ open, setOpen }: BanGroupModalProps) => {
 
     const formik = useFormik<BanGroupFormValues>({
         initialValues: {
-            banType: BanType.NoComm,
+            steam_id: '',
             duration: Duration.dur2w,
-            durationCustom: '',
+            duration_custom: '',
             note: '',
-            reason: BanReason.Cheating,
-            groupId: '',
-            reasonText: ''
+            group_id: ''
         },
         validateOnBlur: true,
         validateOnChange: false,
-        onReset: () => {},
         validationSchema: validationSchema,
         onSubmit: async (values) => {
+            console.log('fire');
             try {
                 await apiCreateBanGroup({
+                    group_id: values.group_id,
                     note: values.note,
-                    ban_type: values.banType,
+                    ban_type: BanType.Banned,
                     duration: values.duration,
-                    reason: values.reason,
-                    reason_text: values.reasonText,
-                    target_id: values.groupId
+                    target_id: values.steam_id
                 });
                 sendFlash('success', 'Ban created successfully');
             } catch (e) {
@@ -94,9 +76,11 @@ export const BanGroupModal = ({ open, setOpen }: BanGroupModalProps) => {
             }
         }
     });
+
     const formId = 'banGroupForm';
+
     return (
-        <form onSubmit={formik.handleSubmit} id={'banForm'}>
+        <form onSubmit={formik.handleSubmit} id={formId}>
             <Dialog
                 fullWidth
                 open={open}
@@ -111,10 +95,8 @@ export const BanGroupModal = ({ open, setOpen }: BanGroupModalProps) => {
                 <DialogContent>
                     <Stack spacing={2}>
                         <Stack spacing={3} alignItems={'center'}>
+                            <SteamIdField fullWidth={true} formik={formik} />
                             <GroupIdField formik={formik} />
-                            <BanTypeField formik={formik} />
-                            <BanReasonField formik={formik} />
-                            <BanReasonTextField formik={formik} />
                             <DurationField formik={formik} />
                             <DurationCustomField formik={formik} />
                             <NoteField formik={formik} />

--- a/frontend/src/component/BanSteamModal.tsx
+++ b/frontend/src/component/BanSteamModal.tsx
@@ -30,6 +30,7 @@ import {
     BanReasonTextField,
     BanReasonTextFieldValidator
 } from './formik/BanReasonTextField';
+import { IncludeFriendsField } from './formik/IncludeFriendsField';
 
 export interface BanModalProps {
     open: boolean;
@@ -46,6 +47,7 @@ interface BanSteamFormValues extends SteamIDInputValue {
     duration: Duration;
     durationCustom: string;
     note: string;
+    include_friends: boolean;
 }
 
 const validationSchema = yup.object({
@@ -80,7 +82,8 @@ export const BanSteamModal = ({
             reason: BanReason.Cheating,
             steam_id: steamId ?? '',
             reasonText: '',
-            reportId: reportId
+            reportId: reportId,
+            include_friends: false
         },
         validateOnBlur: true,
         validateOnChange: false,
@@ -97,7 +100,8 @@ export const BanSteamModal = ({
                     reason: values.reason,
                     reason_text: values.reasonText,
                     report_id: values.reportId,
-                    target_id: values.steam_id
+                    target_id: values.steam_id,
+                    include_friends: values.include_friends
                 });
                 sendFlash('success', 'Ban created successfully');
             } catch (e) {
@@ -108,7 +112,9 @@ export const BanSteamModal = ({
             }
         }
     });
+
     const formId = 'banSteamForm';
+
     return (
         <form onSubmit={formik.handleSubmit} id={formId}>
             <Dialog
@@ -133,6 +139,7 @@ export const BanSteamModal = ({
                         <BanTypeField formik={formik} />
                         <BanReasonField formik={formik} />
                         <BanReasonTextField formik={formik} />
+                        <IncludeFriendsField formik={formik} />
                         <DurationField formik={formik} />
                         <DurationCustomField formik={formik} />
                         <NoteField formik={formik} />

--- a/frontend/src/component/BanSteamModal.tsx
+++ b/frontend/src/component/BanSteamModal.tsx
@@ -40,12 +40,12 @@ export interface BanModalProps {
 }
 
 interface BanSteamFormValues extends SteamIDInputValue {
-    reportId?: number;
-    banType: BanType;
+    report_id?: number;
+    ban_type: BanType;
     reason: BanReason;
-    reasonText: string;
+    reason_text: string;
     duration: Duration;
-    durationCustom: string;
+    duration_custom: string;
     note: string;
     include_friends: boolean;
 }
@@ -75,14 +75,14 @@ export const BanSteamModal = ({
 
     const formik = useFormik<BanSteamFormValues>({
         initialValues: {
-            banType: BanType.NoComm,
+            ban_type: BanType.NoComm,
             duration: Duration.dur2w,
-            durationCustom: '',
+            duration_custom: '',
             note: '',
             reason: BanReason.Cheating,
             steam_id: steamId ?? '',
-            reasonText: '',
-            reportId: reportId,
+            reason_text: '',
+            report_id: reportId,
             include_friends: false
         },
         validateOnBlur: true,
@@ -95,11 +95,11 @@ export const BanSteamModal = ({
             try {
                 await apiCreateBanSteam({
                     note: values.note,
-                    ban_type: values.banType,
+                    ban_type: values.ban_type,
                     duration: values.duration,
                     reason: values.reason,
-                    reason_text: values.reasonText,
-                    report_id: values.reportId,
+                    reason_text: values.reason_text,
+                    report_id: values.report_id,
                     target_id: values.steam_id,
                     include_friends: values.include_friends
                 });

--- a/frontend/src/component/formik/ASNumberField.tsx
+++ b/frontend/src/component/formik/ASNumberField.tsx
@@ -13,7 +13,7 @@ export const ASNumberField = ({
     formik
 }: {
     formik: FormikState<{
-        asNum: number;
+        as_num: number;
     }> &
         FormikHandlers;
 }) => {
@@ -22,12 +22,12 @@ export const ASNumberField = ({
             type={'number'}
             fullWidth
             label={'Autonomous System Number'}
-            id={'asNum'}
-            name={'asNum'}
-            value={formik.values.asNum}
+            id={'as_num'}
+            name={'as_num'}
+            value={formik.values.as_num}
             onChange={formik.handleChange}
-            error={formik.touched.asNum && Boolean(formik.errors.asNum)}
-            helperText={formik.touched.asNum && formik.errors.asNum}
+            error={formik.touched.as_num && Boolean(formik.errors.as_num)}
+            helperText={formik.touched.as_num && formik.errors.as_num}
         />
     );
 };

--- a/frontend/src/component/formik/BanReasonTextField.tsx
+++ b/frontend/src/component/formik/BanReasonTextField.tsx
@@ -18,23 +18,23 @@ export const BanReasonTextField = ({
 }: {
     formik: FormikState<{
         reason: BanReason;
-        reasonText: string;
+        reason_text: string;
     }> &
         FormikHandlers;
 }) => {
     return (
         <TextField
             fullWidth
-            id="reasonText"
-            name={'reasonText'}
+            id="reason_text"
+            name={'reason_text'}
             label="Custom Reason"
             disabled={formik.values.reason != BanReason.Custom}
-            value={formik.values.reasonText}
+            value={formik.values.reason_text}
             onChange={formik.handleChange}
             error={
-                formik.touched.reasonText && Boolean(formik.errors.reasonText)
+                formik.touched.reason_text && Boolean(formik.errors.reason_text)
             }
-            helperText={formik.touched.reasonText && formik.errors.reasonText}
+            helperText={formik.touched.reason_text && formik.errors.reason_text}
             variant="outlined"
         />
     );

--- a/frontend/src/component/formik/BanTypeField.tsx
+++ b/frontend/src/component/formik/BanTypeField.tsx
@@ -17,7 +17,7 @@ export const BanTypeField = ({
     formik
 }: {
     formik: FormikState<{
-        banType: BanType;
+        ban_type: BanType;
     }> &
         FormikHandlers;
 }) => {
@@ -28,11 +28,13 @@ export const BanTypeField = ({
                 fullWidth
                 label={'Action Type'}
                 labelId="actionType-label"
-                id="banType"
-                name={'banType'}
-                value={formik.values.banType}
+                id="ban_type"
+                name={'ban_type'}
+                value={formik.values.ban_type}
                 onChange={formik.handleChange}
-                error={formik.touched.banType && Boolean(formik.errors.banType)}
+                error={
+                    formik.touched.ban_type && Boolean(formik.errors.ban_type)
+                }
                 defaultValue={BanType.Banned}
             >
                 {[BanType.Banned, BanType.NoComm].map((v) => (
@@ -42,7 +44,7 @@ export const BanTypeField = ({
                 ))}
             </Select>
             <FormHelperText>
-                {formik.touched.banType && formik.errors.banType}
+                {formik.touched.ban_type && formik.errors.ban_type}
             </FormHelperText>
         </FormControl>
     );

--- a/frontend/src/component/formik/BaseFormikInputProps.tsx
+++ b/frontend/src/component/formik/BaseFormikInputProps.tsx
@@ -1,0 +1,10 @@
+import { FormikHandlers, FormikState } from 'formik/dist/types';
+
+export interface BaseFormikInputProps<T> {
+    id?: string;
+    label?: string;
+    initialValue?: string;
+    fullWidth?: boolean;
+    isReadOnly?: boolean;
+    formik: FormikState<T> & FormikHandlers;
+}

--- a/frontend/src/component/formik/DurationCustomField.tsx
+++ b/frontend/src/component/formik/DurationCustomField.tsx
@@ -13,7 +13,7 @@ export const DurationCustomField = ({
 }: {
     formik: FormikState<{
         duration: Duration;
-        durationCustom: string;
+        duration_custom: string;
     }> &
         FormikHandlers;
 }) => {
@@ -21,17 +21,17 @@ export const DurationCustomField = ({
         <TextField
             fullWidth
             label={'Custom Duration'}
-            id={'durationCustom'}
-            name={'durationCustom'}
+            id={'duration_custom'}
+            name={'duration_custom'}
             disabled={formik.values.duration != Duration.durCustom}
-            value={formik.values.durationCustom}
+            value={formik.values.duration_custom}
             onChange={formik.handleChange}
             error={
-                formik.touched.durationCustom &&
-                Boolean(formik.errors.durationCustom)
+                formik.touched.duration_custom &&
+                Boolean(formik.errors.duration_custom)
             }
             helperText={
-                formik.touched.durationCustom && formik.errors.durationCustom
+                formik.touched.duration_custom && formik.errors.duration_custom
             }
         />
     );

--- a/frontend/src/component/formik/GroupIdField.tsx
+++ b/frontend/src/component/formik/GroupIdField.tsx
@@ -5,26 +5,26 @@ import * as yup from 'yup';
 
 export const GroupIdFieldValidator = yup
     .string()
-    .min(10, 'Must be positive integer');
+    .length(18, 'Must be positive integer');
 
 export const GroupIdField = ({
     formik
 }: {
     formik: FormikState<{
-        groupId: string;
+        group_id: string;
     }> &
         FormikHandlers;
 }) => {
     return (
         <TextField
             fullWidth
-            id="groupId"
-            name={'groupId'}
+            id="group_id"
+            name={'group_id'}
             label="Steam Group ID"
-            value={formik.values.groupId}
+            value={formik.values.group_id}
             onChange={formik.handleChange}
-            error={formik.touched.groupId && Boolean(formik.errors.groupId)}
-            helperText={formik.touched.groupId && formik.errors.groupId}
+            error={formik.touched.group_id && Boolean(formik.errors.group_id)}
+            helperText={formik.touched.group_id && formik.errors.group_id}
             variant="outlined"
         />
     );

--- a/frontend/src/component/formik/IncludeFriendsField.tsx
+++ b/frontend/src/component/formik/IncludeFriendsField.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import FormGroup from '@mui/material/FormGroup';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Checkbox from '@mui/material/Checkbox';
+import { BaseFormikInputProps } from './BaseFormikInputProps';
+import Tooltip from '@mui/material/Tooltip';
+
+interface IncludeFriendsFieldValue {
+    include_friends: boolean;
+}
+
+export const IncludeFriendsField = ({
+    formik,
+    isReadOnly
+}: BaseFormikInputProps<IncludeFriendsFieldValue>) => {
+    return (
+        <FormGroup>
+            <Tooltip
+                title={
+                    'Periodically update known friends lists and include them in the ban'
+                }
+            >
+                <FormControlLabel
+                    control={
+                        <Checkbox
+                            checked={formik.values.include_friends}
+                            disabled={isReadOnly ?? false}
+                        />
+                    }
+                    label="Include Friends"
+                    name={'include_friends'}
+                    onChange={formik.handleChange}
+                />
+            </Tooltip>
+        </FormGroup>
+    );
+};

--- a/frontend/src/component/formik/ReportIdField.tsx
+++ b/frontend/src/component/formik/ReportIdField.tsx
@@ -12,7 +12,7 @@ export const ReportIdField = ({
     formik
 }: {
     formik: FormikState<{
-        reportId?: number;
+        report_id?: number;
     }> &
         FormikHandlers;
 }) => {
@@ -25,7 +25,7 @@ export const ReportIdField = ({
             name={'report_id'}
             disabled={true}
             hidden={true}
-            value={formik.values.reportId}
+            value={formik.values.report_id}
             onChange={formik.handleChange}
         />
     );

--- a/frontend/src/page/AdminBan.tsx
+++ b/frontend/src/page/AdminBan.tsx
@@ -379,6 +379,23 @@ export const AdminBan = () => {
                                         }
                                     },
                                     {
+                                        label: 'Friends Incl.',
+                                        tooltip:
+                                            'Are friends also included in the ban',
+                                        align: 'left',
+                                        width: '150px',
+                                        sortKey: 'include_friends',
+                                        renderer: (row) => {
+                                            return (
+                                                <Typography variant={'body1'}>
+                                                    {row.include_friends
+                                                        ? 'yes'
+                                                        : 'no'}
+                                                </Typography>
+                                            );
+                                        }
+                                    },
+                                    {
                                         label: 'Rep.',
                                         tooltip: 'Report',
                                         sortable: false,
@@ -812,25 +829,17 @@ export const AdminBan = () => {
                                 )
                             },
                             {
-                                label: 'Reason',
-                                tooltip: 'Reason',
-                                sortKey: 'reason',
-                                sortable: true,
-                                align: 'left',
-                                queryValue: (o) => BanReason[o.reason],
-                                renderer: (row) => (
-                                    <Typography variant={'body1'}>
-                                        {BanReason[row.reason]}
-                                    </Typography>
-                                )
-                            },
-                            {
-                                label: 'Custom Reason',
-                                tooltip: 'Custom',
-                                sortKey: 'reason_text',
+                                label: 'Note',
+                                tooltip: 'Mod Note',
+                                sortKey: 'note',
                                 sortable: false,
                                 align: 'left',
-                                queryValue: (o) => o.reason_text
+                                queryValue: (row) => row.note,
+                                renderer: (row) => (
+                                    <Typography variant={'body1'}>
+                                        {row.note}
+                                    </Typography>
+                                )
                             },
                             {
                                 label: 'Created',

--- a/internal/app/app_background.go
+++ b/internal/app/app_background.go
@@ -18,19 +18,20 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-func (app *App) IsSteamGroupBanned(steamID steamid.SID64) bool {
+// IsGroupBanned checks membership in the currently known banned group members or friends of banned users marked with `include_friends`
+func (app *App) IsGroupBanned(steamID steamid.SID64) (int64, bool) {
 	app.bannedGroupMembersMu.RLock()
 	defer app.bannedGroupMembersMu.RUnlock()
 
-	for _, groupMembers := range app.bannedGroupMembers {
+	for parentID, groupMembers := range app.bannedGroupMembers {
 		for _, member := range groupMembers {
 			if steamID == member {
-				return true
+				return parentID, true
 			}
 		}
 	}
 
-	return false
+	return 0, false
 }
 
 // activeMatchContext represents the current match on any given server instance.

--- a/internal/app/app_background.go
+++ b/internal/app/app_background.go
@@ -175,7 +175,7 @@ func (app *App) updateSteamBanMembers(ctx context.Context) (map[int64]steamid.Co
 		}
 
 		if len(friends) == 0 {
-			return newMap, nil
+			continue
 		}
 
 		var sids steamid.Collection
@@ -223,7 +223,7 @@ func (app *App) updateGroupBanMembers(ctx context.Context) (map[int64]steamid.Co
 		}
 
 		if len(members) == 0 {
-			return newMap, nil
+			continue
 		}
 
 		memberList := store.NewMembersList(group.GroupID.Int64(), members)

--- a/internal/app/app_discord.go
+++ b/internal/app/app_discord.go
@@ -1535,6 +1535,7 @@ func makeOnMute(app *App) discord.CommandHandler {
 			store.Bot,
 			0,
 			store.NoComm,
+			false,
 			&banSteam,
 		); errOpts != nil {
 			return nil, errors.Wrapf(errOpts, "Failed to parse options")
@@ -1714,6 +1715,7 @@ func onBanSteam(ctx context.Context, app *App, _ *discordgo.Session,
 		store.Bot,
 		0,
 		store.Banned,
+		false,
 		&banSteam,
 	); errOpts != nil {
 		return nil, errors.Wrapf(errOpts, "Failed to parse options")

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -135,8 +135,6 @@ type generalConfig struct {
 	MasterServerStatusUpdateFreq string         `mapstructure:"master_server_status_update_freq"`
 	DefaultMaps                  []string       `mapstructure:"default_maps"`
 	ExternalURL                  string         `mapstructure:"external_url"`
-	BannedSteamGroupIds          []steamid.GID  `mapstructure:"banned_steam_group_ids"`
-	BannedServersAddresses       []string       `mapstructure:"banned_server_addresses"`
 }
 
 type discordConfig struct {

--- a/internal/app/http_api.go
+++ b/internal/app/http_api.go
@@ -581,16 +581,17 @@ func onAPIPostBansCIDRCreate(app *App) gin.HandlerFunc {
 
 func onAPIPostBanSteamCreate(app *App) gin.HandlerFunc {
 	type apiBanRequest struct {
-		SourceID   store.StringSID `json:"source_id"`
-		TargetID   store.StringSID `json:"target_id"`
-		Duration   string          `json:"duration"`
-		BanType    store.BanType   `json:"ban_type"`
-		Reason     store.Reason    `json:"reason"`
-		ReasonText string          `json:"reason_text"`
-		Note       string          `json:"note"`
-		ReportID   int64           `json:"report_id"`
-		DemoName   string          `json:"demo_name"`
-		DemoTick   int             `json:"demo_tick"`
+		SourceID       store.StringSID `json:"source_id"`
+		TargetID       store.StringSID `json:"target_id"`
+		Duration       string          `json:"duration"`
+		BanType        store.BanType   `json:"ban_type"`
+		Reason         store.Reason    `json:"reason"`
+		ReasonText     string          `json:"reason_text"`
+		Note           string          `json:"note"`
+		ReportID       int64           `json:"report_id"`
+		DemoName       string          `json:"demo_name"`
+		DemoTick       int             `json:"demo_tick"`
+		IncludeFriends bool            `json:"include_friends"`
 	}
 
 	log := app.log.Named(runtime.FuncForPC(make([]uintptr, 10)[0]).Name())
@@ -624,6 +625,7 @@ func onAPIPostBanSteamCreate(app *App) gin.HandlerFunc {
 			origin,
 			req.ReportID,
 			req.BanType,
+			req.IncludeFriends,
 			&banSteam,
 		); errBanSteam != nil {
 			responseErr(ctx, http.StatusBadRequest, consts.ErrBadRequest)

--- a/internal/app/http_api.go
+++ b/internal/app/http_api.go
@@ -760,9 +760,9 @@ func onAPIPostServerCheck(app *App) gin.HandlerFunc {
 			return
 		}
 
-		if app.IsSteamGroupBanned(steamID) {
+		if parentID, banned := app.IsGroupBanned(steamID); banned {
 			resp.BanType = store.Banned
-			resp.Msg = "Group Banned"
+			resp.Msg = fmt.Sprintf("Group/Steam Friend Ban (source: %d)", parentID)
 			ctx.JSON(http.StatusOK, resp)
 			log.Info("Player dropped", zap.String("drop_type", "group"),
 				zap.Int64("sid64", steamID.Int64()))

--- a/internal/store/ban.go
+++ b/internal/store/ban.go
@@ -1061,7 +1061,7 @@ func (db *Store) GetBanGroup(ctx context.Context, groupID steamid.GID, banGroup 
 	SELECT ban_group_id, source_id, target_id, group_name, is_enabled, deleted,
 	note, unban_reason_text, origin, created_on, updated_on, valid_until, appeal_state, group_id
 	FROM ban_group
-	WHERE group_id = $1 AND is_enabled = true AND deleted = false`
+	WHERE group_id = $1 AND deleted = false`
 
 	var (
 		sourceID   int64
@@ -1113,7 +1113,7 @@ func (db *Store) GetBanGroupByID(ctx context.Context, banGroupID int64, banGroup
 		Scan(
 			&banGroup.BanGroupID,
 			&sourceID,
-			targetID,
+			&targetID,
 			&banGroup.GroupName,
 			&banGroup.IsEnabled,
 			&banGroup.Deleted,

--- a/internal/store/migrations/000070_add_members_table.down.sql
+++ b/internal/store/migrations/000070_add_members_table.down.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+drop table if exists members;
+
+ALTER TABLE IF EXISTS ban
+    DROP COLUMN IF EXISTS include_friends;
+
+COMMIT;

--- a/internal/store/migrations/000070_add_members_table.down.sql
+++ b/internal/store/migrations/000070_add_members_table.down.sql
@@ -5,4 +5,6 @@ drop table if exists members;
 ALTER TABLE IF EXISTS ban
     DROP COLUMN IF EXISTS include_friends;
 
+CREATE UNIQUE INDEX ban_group_group_id_uindex ON gbans.public.ban_group (group_id);
+
 COMMIT;

--- a/internal/store/migrations/000070_add_members_table.down.sql
+++ b/internal/store/migrations/000070_add_members_table.down.sql
@@ -5,6 +5,6 @@ drop table if exists members;
 ALTER TABLE IF EXISTS ban
     DROP COLUMN IF EXISTS include_friends;
 
-CREATE UNIQUE INDEX ban_group_group_id_uindex ON gbans.public.ban_group (group_id);
+CREATE UNIQUE INDEX ban_group_group_id_uindex ON ban_group (group_id);
 
 COMMIT;

--- a/internal/store/migrations/000070_add_members_table.up.sql
+++ b/internal/store/migrations/000070_add_members_table.up.sql
@@ -10,6 +10,8 @@ CREATE TABLE members
 
 CREATE UNIQUE INDEX members_parent_id_uindex ON members (parent_id);
 
+DROP INDEX IF EXISTS ban_group_group_id_uindex;
+
 ALTER TABLE ban
     ADD COLUMN include_friends bool default false;
 

--- a/internal/store/migrations/000070_add_members_table.up.sql
+++ b/internal/store/migrations/000070_add_members_table.up.sql
@@ -1,0 +1,16 @@
+BEGIN;
+CREATE TABLE members
+(
+    members_id bigserial primary key,
+    parent_id  bigint,
+    members    jsonb,
+    created_on timestamptz,
+    updated_on timestamptz
+);
+
+CREATE UNIQUE INDEX members_parent_id_uindex ON members (parent_id);
+
+ALTER TABLE ban
+    ADD COLUMN include_friends bool default false;
+
+COMMIT;

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -259,7 +259,7 @@ func testBanSteam(database *store.Store) func(t *testing.T) {
 			store.Cheating,
 			store.Cheating.String(),
 			"Mod Note",
-			store.System, 0, store.Banned, &banSteam), "Failed to create ban opts")
+			store.System, 0, store.Banned, false, &banSteam), "Failed to create ban opts")
 
 		require.NoError(t, database.SaveBan(ctx, &banSteam), "Failed to add ban")
 


### PR DESCRIPTION
Some of this functionaly already existed, however this moves it into the database instead of the static config file.

- Enables the group ban feature in UI
- Adds a `include_friends` field to mark players who friend list will also get dropped. When the parent ban is expired
- Save archive of banned players to reference incase of private profile/group changes
