### PR TITLE
Demo Download & Report Fixes

### DIFF
--- a/frontend/src/component/ReportViewComponent.tsx
+++ b/frontend/src/component/ReportViewComponent.tsx
@@ -220,7 +220,7 @@ export const ReportViewComponent = ({
                                     startIcon={<FileDownloadIcon />}
                                     component={Link}
                                     variant={'text'}
-                                    href={`/demos/${report.demo_id}`}
+                                    href={`${window.gbans.asset_url}/${window.gbans.bucket_demo}/${report.demo_name}`}
                                     color={'primary'}
                                 >
                                     {report.demo_name}

--- a/frontend/src/component/formik/DemoTickField.tsx
+++ b/frontend/src/component/formik/DemoTickField.tsx
@@ -15,6 +15,7 @@ export const DemTickField = <T,>() => {
         <FormControl fullWidth>
             <TextField
                 fullWidth
+                type={'number'}
                 disabled={isSubmitting}
                 id={'demo_tick'}
                 label={'Demo Tick'}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -703,7 +703,7 @@ func (app *App) startWorkers(ctx context.Context) {
 	go cleanupTasks(ctx, app.db, app.log)
 	go app.showReportMeta(ctx)
 	go app.notificationSender(ctx)
-	go demoCleaner(ctx, app.db, app.log)
+	go app.demoCleaner(ctx)
 	go app.stateUpdater(ctx)
 	go app.forumActivityUpdater(ctx)
 }

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -123,6 +123,8 @@ type generalConfig struct {
 	MasterServerStatusUpdateFreq string        `mapstructure:"master_server_status_update_freq"`
 	DefaultMaps                  []string      `mapstructure:"default_maps"`
 	ExternalURL                  string        `mapstructure:"external_url"`
+	DemoCleanupEnabled           bool          `mapstructure:"demo_cleanup_enabled"`
+	DemoCountLimit               uint64        `mapstructure:"demo_count_limit"`
 }
 
 type discordConfig struct {
@@ -251,6 +253,8 @@ func setDefaultConfigValues() {
 		"general.external_url":                     "http://gbans.localhost:6006",
 		"general.banned_steam_group_ids":           []steamid.GID{},
 		"general.banned_server_addresses":          []string{},
+		"general.demo_cleanup_enabled":             true,
+		"general.demo_count_limit":                 10000,
 		"patreon.enabled":                          false,
 		"patreon.client_id":                        "",
 		"patreon.client_secret":                    "",

--- a/internal/app/http_api_server.go
+++ b/internal/app/http_api_server.go
@@ -375,10 +375,19 @@ func onAPIPostDemo(app *App) gin.HandlerFunc {
 				log.Error("Failed to cleanup temp demo path", zap.Error(err))
 			}
 		}()
-		// 20231112-063943-koth_harvest_final.dem
+
 		namePartsAll := strings.Split(demoFormFile.Filename, "-")
-		nameParts := strings.Split(namePartsAll[2], ".")
-		mapName := nameParts[0]
+
+		var mapName string
+
+		if strings.Contains(demoFormFile.Filename, "workshop-") {
+			// 20231221-042605-workshop-cp_overgrown_rc8-ugc503939302.dem
+			mapName = namePartsAll[3]
+		} else {
+			// 20231112-063943-koth_harvest_final.dem
+			nameParts := strings.Split(namePartsAll[2], ".")
+			mapName = nameParts[0]
+		}
 
 		tempPath := filepath.Join(dir, demoFormFile.Filename)
 

--- a/internal/app/s3.go
+++ b/internal/app/s3.go
@@ -16,6 +16,7 @@ import (
 
 type AssetStore interface {
 	Put(ctx context.Context, bucket string, name string, body io.Reader, size int64, contentType string) error
+	Remove(ctx context.Context, bucket string, name string) error
 }
 
 type S3Client struct {


### PR DESCRIPTION
- Fix report demo using old download link
- Update demo cleanup func to remove from S3 as well as limit demo to N rows
- Add demo_cleanup_enabled and demo_count_limit for configuring demo cleanups