### PR TITLE
Add <Title> component and first usage on /servers

### DIFF
--- a/frontend/src/component/Title.tsx
+++ b/frontend/src/component/Title.tsx
@@ -1,0 +1,30 @@
+import { useEffect, useRef } from 'react';
+
+interface TitleProps {
+    // Must be a single string! See https://react.dev/reference/react-dom/components/title#use-variables-in-the-title
+    children: string;
+}
+
+// Sets the window title to the passed in children.
+//
+// Examples:
+//   - <Title>Really cool page</Title>
+//   - <Title>{`Page ${page_number}`}</Title>
+//
+// TODO: Bad things may happen if a route tries to render multiple
+// <Title>s!
+export const Title = ({ children }: TitleProps) => {
+    const originalTitle = useRef<string | undefined>();
+    useEffect(() => {
+        if (originalTitle.current === undefined) {
+            originalTitle.current = document.title;
+        }
+
+        document.title = `${children} | ${window.gbans.site_name}`;
+
+        return () => {
+            document.title = originalTitle.current!;
+        };
+    }, [originalTitle, children]);
+    return null;
+};

--- a/frontend/src/routes/_guest.servers.tsx
+++ b/frontend/src/routes/_guest.servers.tsx
@@ -14,6 +14,7 @@ import { ContainerWithHeader } from '../component/ContainerWithHeader.tsx';
 import { ServerFilters } from '../component/ServerFilters.tsx';
 import { ServerList } from '../component/ServerList.tsx';
 import { ServerMap } from '../component/ServerMap.tsx';
+import { Title } from '../component/Title.tsx';
 import { MapStateCtx } from '../contexts/MapStateCtx.tsx';
 import { useMapStateCtx } from '../hooks/useMapStateCtx.ts';
 import { sum } from '../util/lists.ts';
@@ -145,6 +146,7 @@ function Servers() {
     });
     return (
         <>
+            <Title>Servers</Title>
             <MapStateCtx.Provider
                 value={{
                     servers,


### PR DESCRIPTION
First try at #482 

Incredibly, tanstack router doesn't seem to have a standard solution for page titles: https://github.com/TanStack/router/discussions/1056

That said, I would expect them to eventually follow React's API lead: https://react.dev/reference/react-dom/components/title#set-the-document-title so I made a very simple `<Title>` component which should be easy to swap out to `<title>` in the future.

As far I saw this app has no SSR, so I just directly mutate document.title.

Would you prefer the title always end in `| ${site_name}`? We can likely inject that from the vite config.