### PR TITLE
Switch frontend globals to use Vite defines

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -33,15 +33,7 @@
 
         <meta name="msapplication-TileColor" content="#941739" />
         <meta name="theme-color" content="#ffffff" />
-        <title><%= site_name %></title>
-        <script>
-            window.gbans = {
-                site_name: "<%= site_name %>",
-                build_version: "<%= build_version %>",
-                discord_link_id: "<%= discord_link_id %>",
-                asset_url: "<%= asset_url %>",
-            }
-        </script>
+        <title><%= __SITE_NAME__ %></title>
         <style>
             body {
                 overflow-y: scroll;

--- a/frontend/src/api/media.ts
+++ b/frontend/src/api/media.ts
@@ -1,6 +1,6 @@
 import { apiCall, TimeStamped, transformTimeStampedDates } from './common';
 
-const assetUrl = (bucket: string, asset: Asset): string => `${window.gbans.asset_url}/${bucket}/${asset.name}`;
+const assetUrl = (bucket: string, asset: Asset): string => `${__ASSET_URL__}/${bucket}/${asset.name}`;
 
 export const assetURLMedia = (asset: Asset) => assetUrl('media', asset);
 

--- a/frontend/src/component/Footer.tsx
+++ b/frontend/src/component/Footer.tsx
@@ -11,10 +11,10 @@ export const Footer = (): JSX.Element => {
     const theme = useTheme();
 
     const gbansUrl = useMemo(() => {
-        if (window.gbans.build_version == 'master') {
+        if (__BUILD_VERSION__ == 'master') {
             return 'https://github.com/leighmacdonald/gbans/tree/master';
-        } else if (window.gbans.build_version.startsWith('v')) {
-            return `https://github.com/leighmacdonald/gbans/releases/tag/${window.gbans.build_version}`;
+        } else if (__BUILD_VERSION__.startsWith('v')) {
+            return `https://github.com/leighmacdonald/gbans/releases/tag/${__BUILD_VERSION__}`;
         }
         return 'https://github.com/leighmacdonald/gbans';
     }, []);
@@ -32,7 +32,7 @@ export const Footer = (): JSX.Element => {
             <Grid container spacing={0} direction="column" alignItems="center" justifyContent="center">
                 <Grid xs={3}>
                     <Typography variant={'subtitle2'} color={'text'}>
-                        Copyright &copy; {window.gbans.site_name || 'gbans'} {new Date().getFullYear()}{' '}
+                        Copyright &copy; {__SITE_NAME__} {new Date().getFullYear()}{' '}
                     </Typography>
                     <Stack
                         // direction={'row'}
@@ -45,7 +45,7 @@ export const Footer = (): JSX.Element => {
                             to={gbansUrl}
                             sx={{ color: theme.palette.text.primary }}
                         >
-                            {window.gbans.build_version}
+                            {__BUILD_VERSION__}
                         </Link>
                         <Link
                             component={RouterLink}

--- a/frontend/src/component/MarkdownRenderer.tsx
+++ b/frontend/src/component/MarkdownRenderer.tsx
@@ -10,7 +10,7 @@ const renderLinks = (body_md: string): string => {
     return body_md
         .replace('/^[\u200B\u200C\u200D\u200E\u200F\uFEFF]/', '')
         .replace(/(wiki:\/\/)/gi, '/wiki/')
-        .replace(/(media:\/\/)/gi, window.gbans.asset_url != '' ? window.gbans.asset_url : '/asset' + '/');
+        .replace(/(media:\/\/)/gi, __ASSET_URL__ != '' ? __ASSET_URL__ : '/asset' + '/');
 };
 
 interface MDImgProps {

--- a/frontend/src/component/Title.tsx
+++ b/frontend/src/component/Title.tsx
@@ -20,7 +20,7 @@ export const Title = ({ children }: TitleProps) => {
             originalTitle.current = document.title;
         }
 
-        document.title = `${children} | ${window.gbans.site_name}`;
+        document.title = `${children} | ${__SITE_NAME__}`;
 
         return () => {
             document.title = originalTitle.current!;

--- a/frontend/src/component/Title.tsx
+++ b/frontend/src/component/Title.tsx
@@ -1,0 +1,30 @@
+import { useEffect, useRef } from 'react';
+
+interface TitleProps {
+    // Must be a single string! See https://react.dev/reference/react-dom/components/title#use-variables-in-the-title
+    children: string;
+}
+
+// Sets the window title to the passed in children.
+//
+// Examples:
+//   - <Title>Really cool page</Title>
+//   - <Title>{`Page ${page_number}`}</Title>
+//
+// TODO: Bad things may happen if a route tries to render multiple
+// <Title>s!
+export const Title = ({ children }: TitleProps) => {
+    const originalTitle = useRef<string | undefined>();
+    useEffect(() => {
+        if (originalTitle.current === undefined) {
+            originalTitle.current = document.title;
+        }
+
+        document.title = `${children} | ${window.gbans.site_name}`;
+
+        return () => {
+            document.title = originalTitle.current!;
+        };
+    }, [originalTitle, children]);
+    return null;
+};

--- a/frontend/src/component/TopBar.tsx
+++ b/frontend/src/component/TopBar.tsx
@@ -317,7 +317,7 @@ export const TopBar = () => {
                             ...tf2Fonts
                         }}
                     >
-                        {window.gbans.site_name || 'gbans'}
+                        {__SITE_NAME__}
                     </Typography>
 
                     <Box
@@ -367,7 +367,7 @@ export const TopBar = () => {
                             display: { xs: 'flex', md: 'none' }
                         }}
                     >
-                        {window.gbans.site_name || 'gbans'}
+                        {__SITE_NAME__}
                     </Typography>
                     <Box
                         sx={{

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -11,11 +11,7 @@ import './fonts/tf2build.css';
 declare global {
     interface Window {
         gbans: {
-            site_name: string;
             discord_client_id: string;
-            discord_link_id: string;
-            asset_url: string;
-            build_version: string;
             build_date: string;
             build_commit: string;
             sentry_dsn_web: string;
@@ -29,7 +25,7 @@ if (window.gbans.sentry_dsn_web != '') {
     // TODO instrumentation for tanstack router, not currently officially supported
     Sentry.init({
         dsn: window.gbans.sentry_dsn_web,
-        release: window.gbans.build_version,
+        release: __BUILD_VERSION__,
         // Performance Monitoring
         tracesSampleRate: 1.0, //  Capture 100% of the transactions
         // Session Replay

--- a/frontend/src/routes/_auth.forums.index.tsx
+++ b/frontend/src/routes/_auth.forums.index.tsx
@@ -205,7 +205,7 @@ function ForumOverview() {
     return (
         <Grid container spacing={3}>
             <Grid xs={12}>
-                <Typography variant={'h2'}>{window.gbans.site_name} community</Typography>
+                <Typography variant={'h2'}>{__SITE_NAME__} community</Typography>
             </Grid>
             <Grid md={9} xs={12}>
                 <Stack spacing={3}>

--- a/frontend/src/routes/_guest.index.tsx
+++ b/frontend/src/routes/_guest.index.tsx
@@ -135,14 +135,14 @@ function Index() {
                         Stats (Beta)
                     </Button>
 
-                    {window.gbans.discord_link_id != '' && (
+                    {__DISCORD_LINK_ID__ != '' && (
                         <Button
                             component={Link}
                             startIcon={<MarkUnreadChatAltIcon />}
                             fullWidth
                             sx={{ backgroundColor: '#5865F2' }}
                             variant={'contained'}
-                            href={`https://discord.gg/${window.gbans.discord_link_id}`}
+                            href={`https://discord.gg/${__DISCORD_LINK_ID__}`}
                         >
                             Join Discord
                         </Button>

--- a/frontend/src/routes/_guest.privacy-policy.tsx
+++ b/frontend/src/routes/_guest.privacy-policy.tsx
@@ -29,8 +29,8 @@ function PrivacyPolicy() {
                     <ul>
                         <li>
                             Where it is necessary for the purposes of the legitimate and legal interests of{' '}
-                            {window.gbans.site_name}, except where such interests are overridden by your prevailing
-                            legitimate interests and rights; or
+                            {__SITE_NAME__}, except where such interests are overridden by your prevailing legitimate
+                            interests and rights; or
                         </li>
                         <li>Where you have given consent to it.</li>
                     </ul>
@@ -125,9 +125,9 @@ function PrivacyPolicy() {
                         If you would like to delete your account, please contact an admin through the account you wish
                         to delete including reason for deletion. If you do not provide a reason for account deletion,
                         your request will not be granted. We make no guarantee that your request will be granted even if
-                        a reason is provided. Per GDPR Article 6(1)(f), {window.gbans.site_name} is lawfully permitted
-                        to dismiss account deletion requests to protect the legitimate interests of our community by
-                        thwarting ban evasions and/or circumvention of our permissions system(s).
+                        a reason is provided. Per GDPR Article 6(1)(f), {__SITE_NAME__} is lawfully permitted to dismiss
+                        account deletion requests to protect the legitimate interests of our community by thwarting ban
+                        evasions and/or circumvention of our permissions system(s).
                     </Typography>
                 </PPBox>
                 <PPBox heading={'Data Usage and Retention'}>

--- a/frontend/src/routes/_guest.servers.tsx
+++ b/frontend/src/routes/_guest.servers.tsx
@@ -14,6 +14,7 @@ import { ContainerWithHeader } from '../component/ContainerWithHeader.tsx';
 import { ServerFilters } from '../component/ServerFilters.tsx';
 import { ServerList } from '../component/ServerList.tsx';
 import { ServerMap } from '../component/ServerMap.tsx';
+import { Title } from '../component/Title.tsx';
 import { MapStateCtx } from '../contexts/MapStateCtx.tsx';
 import { useMapStateCtx } from '../hooks/useMapStateCtx.ts';
 import { sum } from '../util/lists.ts';
@@ -145,6 +146,7 @@ function Servers() {
     });
     return (
         <>
+            <Title>Servers</Title>
             <MapStateCtx.Provider
                 value={{
                     servers,

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,1 +1,5 @@
 /// <reference types="vite/client" />
+declare const __SITE_NAME__: string;
+declare const __BUILD_VERSION__: string;
+declare const __DISCORD_LINK_ID__: string;
+declare const __ASSET_URL__: string;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,6 +4,15 @@ import react from '@vitejs/plugin-react-swc';
 import { defineConfig } from 'vite';
 import { createHtmlPlugin } from 'vite-plugin-html';
 
+const CONFIG = {
+    __SITE_NAME__: 'Uncletopia',
+    __BUILD_VERSION__: 'v0.7.4',
+    __DISCORD_LINK_ID__: 'caQKCWFMrN',
+    __ASSET_URL__: ''
+};
+
+const mapValues = (o, fn) => Object.fromEntries(Object.entries(o).map(([k, v]) => [k, fn(v)]));
+
 // https://vitejs.dev/config/
 export default defineConfig({
     base: '/',
@@ -21,6 +30,10 @@ export default defineConfig({
             }
         }
     },
+
+    // https://vitejs.dev/config/shared-options.html#define
+    define: mapValues(CONFIG, JSON.stringify),
+
     server: {
         open: true,
         port: 6007,
@@ -53,12 +66,7 @@ export default defineConfig({
             template: 'index.html',
 
             inject: {
-                data: {
-                    site_name: 'Uncletopia',
-                    build_version: 'v0.7.4',
-                    discord_link_id: 'caQKCWFMrN',
-                    asset_url: ''
-                }
+                data: CONFIG
             }
         })
     ]


### PR DESCRIPTION
I did this refactor for https://github.com/leighmacdonald/gbans/pull/503 before realizing I could just use `window.gbans.site_name`

Figured I'd offer this to you anyways as using Vite defines is a bit more idiomatic and compiles a little more efficiently (it saves ~200 bytes off of index.html and ~1kb off of index.js)

I tested by poking around the site and also running `./node_modules/.bin/tsc --noEmit` and noticing no new type errors. release.sh also still works.

This PR temporarily is stacked on top of the commit from https://github.com/leighmacdonald/gbans/pull/503... sorry, I'm not sure about modern github etiquette for stacked commits, I'll sort it out as that PR lands. 