### PR TITLE
Add titles to more pages

### DIFF
--- a/frontend/src/routes/_admin.admin.servers.tsx
+++ b/frontend/src/routes/_admin.admin.servers.tsx
@@ -27,6 +27,7 @@ import { PaginatorLocal } from '../component/PaginatorLocal.tsx';
 import { TableCellBool } from '../component/TableCellBool.tsx';
 import { TableCellString } from '../component/TableCellString.tsx';
 import { TableHeadingCell } from '../component/TableHeadingCell.tsx';
+import { Title } from '../component/Title';
 import { TableCellStringHidden } from '../component/field/TableCellStringHidden.tsx';
 import { ModalServerEditor } from '../component/modal';
 import { useUserFlashCtx } from '../hooks/useUserFlashCtx.ts';
@@ -89,6 +90,7 @@ function AdminServers() {
     };
     return (
         <Grid container spacing={2}>
+            <Title>Edit Servers</Title>
             <Grid xs={12}>
                 <Stack spacing={2}>
                     <ContainerWithHeaderAndButtons

--- a/frontend/src/routes/_auth.ban.$ban_id.tsx
+++ b/frontend/src/routes/_auth.ban.$ban_id.tsx
@@ -41,6 +41,7 @@ import { ProfileInfoBox } from '../component/ProfileInfoBox.tsx';
 import RouterLink from '../component/RouterLink.tsx';
 import { SourceBansList } from '../component/SourceBansList.tsx';
 import { SteamIDList } from '../component/SteamIDList.tsx';
+import { Title } from '../component/Title';
 import { Buttons } from '../component/field/Buttons.tsx';
 import { MarkdownField } from '../component/field/MarkdownField.tsx';
 import { ModalBanSteam, ModalUnbanSteam } from '../component/modal';
@@ -144,6 +145,7 @@ function BanPage() {
     const modTools = useMemo(() => {
         return (
             <ContainerWithHeader title={'Moderation Tools'} iconLeft={<AddModeratorIcon />}>
+                <Title>Moderation Tools</Title>
                 <Stack spacing={2} padding={2}>
                     <Stack direction={'row'} spacing={2}>
                         {!expired && (

--- a/frontend/src/routes/_auth.chatlogs.tsx
+++ b/frontend/src/routes/_auth.chatlogs.tsx
@@ -16,6 +16,7 @@ import { apiGetMessages, apiGetServers, PermissionLevel, ServerSimple } from '..
 import { ChatTable } from '../component/ChatTable.tsx';
 import { ContainerWithHeader } from '../component/ContainerWithHeader.tsx';
 import { Paginator } from '../component/Paginator.tsx';
+import { Title } from '../component/Title.tsx';
 import { Buttons } from '../component/field/Buttons.tsx';
 import { SteamIDField } from '../component/field/SteamIDField.tsx';
 import { TextFieldSimple } from '../component/field/TextFieldSimple.tsx';
@@ -135,6 +136,7 @@ function ChatLogs() {
     };
     return (
         <>
+            <Title>Chat Logs</Title>
             <Grid container spacing={2}>
                 <Grid xs={12}>
                     <ContainerWithHeader title={'Chat Filters'} iconLeft={<FilterAltIcon />}>

--- a/frontend/src/routes/_auth.contests.$contest_id.tsx
+++ b/frontend/src/routes/_auth.contests.$contest_id.tsx
@@ -25,6 +25,7 @@ import { LoadingPlaceholder } from '../component/LoadingPlaceholder.tsx';
 import { LoadingSpinner } from '../component/LoadingSpinner.tsx';
 import { MarkDownRenderer } from '../component/MarkdownRenderer.tsx';
 import { PersonCell } from '../component/PersonCell.tsx';
+import { Title } from '../component/Title';
 import { VCenterBox } from '../component/VCenterBox.tsx';
 import { ModalAssetViewer, ModalContestEntry, ModalContestEntryDelete } from '../component/modal';
 import { useUserFlashCtx } from '../hooks/useUserFlashCtx.ts';
@@ -132,6 +133,7 @@ function Contest() {
     ) : (
         contest && (
             <Grid container spacing={3}>
+                <Title>{contest?.title ?? 'Contest'}</Title>
                 <Grid xs={8}>
                     <ContainerWithHeader
                         title={`Contest: ${contest?.title}`}

--- a/frontend/src/routes/_auth.forums.$forum_id.tsx
+++ b/frontend/src/routes/_auth.forums.$forum_id.tsx
@@ -21,6 +21,7 @@ import { ForumRowLink } from '../component/ForumRowLink.tsx';
 import { VCenteredElement } from '../component/Heading.tsx';
 import { PaginatorLocal } from '../component/PaginatorLocal.tsx';
 import RouterLink from '../component/RouterLink.tsx';
+import { Title } from '../component/Title';
 import { VCenterBox } from '../component/VCenterBox.tsx';
 import { ModalForumForumEditor, ModalForumThreadCreator } from '../component/modal';
 import { AppError } from '../error.tsx';
@@ -136,6 +137,7 @@ function ForumPage() {
 
     return (
         <ContainerWithHeaderAndButtons title={forum.title} iconLeft={<MessageIcon />} buttons={headerButtons}>
+            <Title>Forums</Title>
             <Stack spacing={2}>
                 {threads.map((t) => {
                     return <ForumThreadRow thread={t} key={`ft-${t.forum_thread_id}`} />;

--- a/frontend/src/routes/_auth.forums.index.tsx
+++ b/frontend/src/routes/_auth.forums.index.tsx
@@ -22,6 +22,7 @@ import { ForumRowLink } from '../component/ForumRowLink.tsx';
 import { VCenteredElement } from '../component/Heading.tsx';
 import { LoadingPlaceholder } from '../component/LoadingPlaceholder.tsx';
 import RouterLink from '../component/RouterLink.tsx';
+import { Title } from '../component/Title';
 import { VCenterBox } from '../component/VCenterBox.tsx';
 import { ModalForumCategoryEditor, ModalForumForumEditor } from '../component/modal';
 import { useUserFlashCtx } from '../hooks/useUserFlashCtx.ts';
@@ -64,6 +65,7 @@ const CategoryBlock = ({ category }: { category: ForumCategory }) => {
 
     return (
         <ContainerWithHeaderAndButtons title={category.title} iconLeft={<CategoryIcon />} buttons={buttons}>
+            <Title>Forums</Title>
             <Stack
                 spacing={1}
                 sx={{

--- a/frontend/src/routes/_auth.forums.thread.$forum_thread_id.tsx
+++ b/frontend/src/routes/_auth.forums.thread.$forum_thread_id.tsx
@@ -28,6 +28,7 @@ import { ThreadMessageContainer } from '../component/ForumThreadMessageContainer
 import { LoadingPlaceholder } from '../component/LoadingPlaceholder.tsx';
 import { PaginatorLocal } from '../component/PaginatorLocal.tsx';
 import RouterLink from '../component/RouterLink.tsx';
+import { Title } from '../component/Title';
 import { VCenterBox } from '../component/VCenterBox.tsx';
 import { Buttons } from '../component/field/Buttons.tsx';
 import { MarkdownField } from '../component/field/MarkdownField.tsx';
@@ -229,6 +230,8 @@ function ForumThreadPage() {
 
     return (
         <Stack spacing={1}>
+            {thread?.title ? <Title>{thread?.title}</Title> : null}
+
             <Stack direction={'row'}>
                 {hasPermission(PermissionLevel.Moderator) && (
                     <IconButton color={'warning'} onClick={onEditThread}>

--- a/frontend/src/routes/_auth.logs.$steamId..tsx
+++ b/frontend/src/routes/_auth.logs.$steamId..tsx
@@ -15,6 +15,7 @@ import { ContainerWithHeader } from '../component/ContainerWithHeader.tsx';
 import { DataTable } from '../component/DataTable.tsx';
 import RouterLink from '../component/RouterLink.tsx';
 import { TableHeadingCell } from '../component/TableHeadingCell.tsx';
+import { Title } from '../component/Title';
 import { commonTableSearchSchema, RowsPerPage } from '../util/table.ts';
 import { renderDateTime } from '../util/text.tsx';
 
@@ -49,6 +50,7 @@ function MatchListPage() {
 
     return (
         <Grid container>
+            <Title>Match History</Title>
             <Grid xs={12}>
                 <MatchSummaryTable matches={matches?.data ?? []} count={matches?.count ?? 0} isLoading={isLoading} />
             </Grid>

--- a/frontend/src/routes/_auth.match.$matchId.tsx
+++ b/frontend/src/routes/_auth.match.$matchId.tsx
@@ -28,6 +28,7 @@ import { PersonCell } from '../component/PersonCell.tsx';
 import { PlayerClassImg } from '../component/PlayerClassImg.tsx';
 import { TableCellSmall } from '../component/TableCellSmall.tsx';
 import { TableHeadingCell } from '../component/TableHeadingCell.tsx';
+import { Title } from '../component/Title';
 import bluLogoImg from '../icons/blu_logo.png';
 import redLogoImg from '../icons/red_logo.png';
 import { PageNotFound } from './_auth.page-not-found.tsx';
@@ -289,6 +290,7 @@ function MatchPage() {
 
     return (
         <ContainerWithHeader title={'Match Results'} iconLeft={<SportsIcon />}>
+            <Title>{match.title}</Title>
             <Grid container spacing={2}>
                 <Grid xs={8}>
                     <Stack>

--- a/frontend/src/routes/_auth.notifications.tsx
+++ b/frontend/src/routes/_auth.notifications.tsx
@@ -14,6 +14,7 @@ import Grid2 from '@mui/material/Unstable_Grid2';
 import { createFileRoute } from '@tanstack/react-router';
 import { parseISO } from 'date-fns';
 import { ContainerWithHeader } from '../component/ContainerWithHeader.tsx';
+import { Title } from '../component/Title';
 import { useNotifications } from '../hooks/useNotifications.ts';
 import { useNotificationsCtx } from '../hooks/useNotificationsCtx.ts';
 import { RowsPerPage } from '../util/table.ts';
@@ -63,6 +64,7 @@ function NotificationsPage() {
 
     return (
         <Grid2 container spacing={2}>
+            <Title>Notifications</Title>
             <Grid2 xs={3}>
                 <ContainerWithHeader title={'Manage'}>
                     <ButtonGroup orientation={'vertical'} variant="contained">

--- a/frontend/src/routes/_auth.report.$reportId.tsx
+++ b/frontend/src/routes/_auth.report.$reportId.tsx
@@ -40,6 +40,7 @@ import { Heading } from '../component/Heading.tsx';
 import { ProfileInfoBox } from '../component/ProfileInfoBox.tsx';
 import { ReportViewComponent } from '../component/ReportViewComponent.tsx';
 import { SteamIDList } from '../component/SteamIDList.tsx';
+import { Title } from '../component/Title';
 import { ModalBanSteam } from '../component/modal';
 import { useUserFlashCtx } from '../hooks/useUserFlashCtx.ts';
 import { logErr } from '../util/errors.ts';
@@ -189,6 +190,7 @@ function ReportView() {
 
     return (
         <Grid container spacing={2}>
+            <Title>Report</Title>
             <Grid xs={12} md={8}>
                 {report && <ReportViewComponent report={report} />}
             </Grid>

--- a/frontend/src/routes/_auth.report.index.tsx
+++ b/frontend/src/routes/_auth.report.index.tsx
@@ -48,6 +48,7 @@ import { PlayerMessageContext } from '../component/PlayerMessageContext.tsx';
 import { ReportStatusIcon } from '../component/ReportStatusIcon.tsx';
 import RouterLink from '../component/RouterLink.tsx';
 import { TableHeadingCell } from '../component/TableHeadingCell.tsx';
+import { Title } from '../component/Title';
 import { Buttons } from '../component/field/Buttons.tsx';
 import { MarkdownField } from '../component/field/MarkdownField.tsx';
 import { SteamIDField } from '../component/field/SteamIDField.tsx';
@@ -89,6 +90,7 @@ function ReportCreate() {
 
     return (
         <Grid container spacing={3}>
+            <Title>Create Report</Title>
             <Grid xs={12} md={8}>
                 <Stack spacing={2}>
                     {canReport && <ReportCreateForm />}

--- a/frontend/src/routes/_auth.settings.tsx
+++ b/frontend/src/routes/_auth.settings.tsx
@@ -12,6 +12,7 @@ import { z } from 'zod';
 import { apiGetPersonSettings, apiSavePersonSettings, PersonSettings } from '../api';
 import { Accordion, AccordionDetails, AccordionSummary } from '../component/Accordian.tsx';
 import { ContainerWithHeader } from '../component/ContainerWithHeader.tsx';
+import { Title } from '../component/Title.tsx';
 import { Buttons } from '../component/field/Buttons.tsx';
 import { CheckboxSimple } from '../component/field/CheckboxSimple.tsx';
 import { MarkdownField } from '../component/field/MarkdownField.tsx';
@@ -83,6 +84,7 @@ function ProfileSettings() {
 
     return (
         <ContainerWithHeader title={'User Settings'} iconLeft={<ConstructionIcon />}>
+            <Title>User Settings</Title>
             <form
                 onSubmit={async (e) => {
                     e.preventDefault();

--- a/frontend/src/routes/_auth.stats.index.tsx
+++ b/frontend/src/routes/_auth.stats.index.tsx
@@ -3,6 +3,7 @@ import { createFileRoute } from '@tanstack/react-router';
 import { HealersOverallContainer } from '../component/HealersOverallContainer.tsx';
 import { MapUsageContainer } from '../component/MapUsageContainer.tsx';
 import { PlayersOverallContainer } from '../component/PlayersOverallContainer.tsx';
+import { Title } from '../component/Title';
 import { WeaponsStatListContainer } from '../component/WeaponsStatListContainer.tsx';
 
 export const Route = createFileRoute('/_auth/stats/')({
@@ -12,6 +13,7 @@ export const Route = createFileRoute('/_auth/stats/')({
 function Stats() {
     return (
         <Grid container spacing={2}>
+            <Title>Stats</Title>
             <Grid xs={12}>
                 <PlayersOverallContainer />
             </Grid>

--- a/frontend/src/routes/_auth.stats.weapon.$weapon_id.tsx
+++ b/frontend/src/routes/_auth.stats.weapon.$weapon_id.tsx
@@ -13,6 +13,7 @@ import { PaginatorLocal } from '../component/PaginatorLocal.tsx';
 import { PersonCell } from '../component/PersonCell';
 import { TableCellSmall } from '../component/TableCellSmall.tsx';
 import { TableHeadingCell } from '../component/TableHeadingCell.tsx';
+import { Title } from '../component/Title';
 import { RowsPerPage } from '../util/table.ts';
 import { defaultFloatFmtPct, humanCount } from '../util/text.tsx';
 
@@ -29,6 +30,7 @@ function StatsWeapon() {
 
     return (
         <Grid container spacing={2}>
+            {data?.weapon?.name ? <Title>{data?.weapon?.name}</Title> : null}
             <Grid xs={12}>
                 <ContainerWithHeader
                     title={`Top 250 Weapon Users: ${isLoading ? 'Loading...' : data?.weapon?.name}`}

--- a/frontend/src/routes/_guest.contests.tsx
+++ b/frontend/src/routes/_guest.contests.tsx
@@ -19,6 +19,7 @@ import RouterLink from '../component/RouterLink.tsx';
 import { TableCellSmall } from '../component/TableCellSmall.tsx';
 import { TableCellString } from '../component/TableCellString.tsx';
 import { TableHeadingCell } from '../component/TableHeadingCell.tsx';
+import { Title } from '../component/Title.tsx';
 import { RowsPerPage } from '../util/table.ts';
 import { renderDateTime } from '../util/text.tsx';
 
@@ -49,6 +50,7 @@ function Contests() {
 
     return (
         <Grid container>
+            <Title>Contests</Title>
             <Grid xs={12}>
                 <ContainerWithHeader title={'Contests'} iconLeft={<InsightsIcon />}>
                     <ContestsTable

--- a/frontend/src/routes/_guest.privacy-policy.tsx
+++ b/frontend/src/routes/_guest.privacy-policy.tsx
@@ -5,6 +5,7 @@ import Typography from '@mui/material/Typography';
 import Grid from '@mui/material/Unstable_Grid2';
 import { createFileRoute } from '@tanstack/react-router';
 import { ContainerWithHeader } from '../component/ContainerWithHeader.tsx';
+import { Title } from '../component/Title.tsx';
 
 export const Route = createFileRoute('/_guest/privacy-policy')({
     component: PrivacyPolicy
@@ -24,6 +25,7 @@ const PPBox = ({ heading, children }: { heading: string; children: ReactNode }) 
 function PrivacyPolicy() {
     return (
         <ContainerWithHeader title={'Privacy Policy'} padding={2} iconLeft={<PolicyIcon />}>
+            <Title>Privacy Policy</Title>
             <Grid container>
                 <PPBox heading={'Why We Collect Personal Information'}>
                     <ul>

--- a/frontend/src/routes/_guest.profile.$steamId.tsx
+++ b/frontend/src/routes/_guest.profile.$steamId.tsx
@@ -18,6 +18,7 @@ import { PlayerClassStatsTable } from '../component/PlayerClassStatsTable.tsx';
 import { PlayerStatsOverallContainer } from '../component/PlayerStatsOverallContainer.tsx';
 import { PlayerWeaponsStatListContainer } from '../component/PlayerWeaponsStatListContainer.tsx';
 import { SteamIDList } from '../component/SteamIDList.tsx';
+import { Title } from '../component/Title';
 import { createExternalLinks } from '../util/history.ts';
 import { avatarHashToURL, isValidSteamDate, renderDateTime } from '../util/text.tsx';
 import { emptyOrNullString } from '../util/types.ts';
@@ -42,6 +43,7 @@ function ProfilePage() {
 
     return (
         <Grid container spacing={2}>
+            {profile.player.personaname ? <Title>{profile.player.personaname}</Title> : null}
             <Grid xs={12} md={8}>
                 <ContainerWithHeader title={'Profile'}>
                     <Grid container spacing={2}>

--- a/frontend/src/routes/_guest.stv.tsx
+++ b/frontend/src/routes/_guest.stv.tsx
@@ -30,6 +30,7 @@ import { DataTable } from '../component/DataTable.tsx';
 import { PaginatorLocal } from '../component/PaginatorLocal.tsx';
 import RouterLink from '../component/RouterLink.tsx';
 import { TableHeadingCell } from '../component/TableHeadingCell.tsx';
+import { Title } from '../component/Title.tsx';
 import { Buttons } from '../component/field/Buttons.tsx';
 import { TextFieldSimple } from '../component/field/TextFieldSimple.tsx';
 import { initColumnFilter, initPagination } from '../types/table.ts';
@@ -219,6 +220,7 @@ function STV() {
 
     return (
         <Grid container spacing={2}>
+            <Title>SourceTV</Title>
             <Grid xs={12}>
                 <ContainerWithHeader title={'Filters'} iconLeft={<FilterListIcon />} marginTop={2}>
                     <form

--- a/frontend/src/routes/_guest.wiki.$slug.tsx
+++ b/frontend/src/routes/_guest.wiki.$slug.tsx
@@ -3,8 +3,10 @@ import { createFileRoute } from '@tanstack/react-router';
 import { PermissionLevel } from '../api';
 import { apiGetWikiPage, Page } from '../api/wiki.ts';
 import { ErrorDetails } from '../component/ErrorDetails.tsx';
+import { Title } from '../component/Title.tsx';
 import { WikiPage } from '../component/WikiPage.tsx';
 import { AppError } from '../error.tsx';
+import { toTitleCase } from '../util/text.tsx';
 
 export const Route = createFileRoute('/_guest/wiki/$slug')({
     component: Wiki,
@@ -42,5 +44,10 @@ export const Route = createFileRoute('/_guest/wiki/$slug')({
 function Wiki() {
     const { slug } = Route.useParams();
 
-    return <WikiPage slug={slug} path={'/_guest/wiki/$slug'} />;
+    return (
+        <>
+            <Title>{toTitleCase(slug.replace(/-/g, ' '))}</Title>
+            <WikiPage slug={slug} path={'/_guest/wiki/$slug'} />
+        </>
+    );
 }

--- a/frontend/src/routes/_guest.wiki.index.tsx
+++ b/frontend/src/routes/_guest.wiki.index.tsx
@@ -2,6 +2,7 @@ import { queryOptions } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
 import { PermissionLevel } from '../api';
 import { apiGetWikiPage, Page } from '../api/wiki.ts';
+import { Title } from '../component/Title.tsx';
 import { WikiPage } from '../component/WikiPage.tsx';
 
 export const Route = createFileRoute('/_guest/wiki/')({
@@ -28,5 +29,10 @@ export const Route = createFileRoute('/_guest/wiki/')({
 });
 
 function Wiki() {
-    return <WikiPage slug={'home'} path={'/_guest/wiki/'} />;
+    return (
+        <>
+            <Title>Wiki</Title>
+            <WikiPage slug={'home'} path={'/_guest/wiki/'} />
+        </>
+    );
 }

--- a/frontend/src/routes/_mod.admin.appeals.tsx
+++ b/frontend/src/routes/_mod.admin.appeals.tsx
@@ -34,6 +34,7 @@ import { PaginatorLocal } from '../component/PaginatorLocal.tsx';
 import { PersonCell } from '../component/PersonCell.tsx';
 import RouterLink from '../component/RouterLink.tsx';
 import { TableHeadingCell } from '../component/TableHeadingCell.tsx';
+import { Title } from '../component/Title';
 import { Buttons } from '../component/field/Buttons.tsx';
 import { SelectFieldSimple } from '../component/field/SelectFieldSimple.tsx';
 import { TextFieldSimple } from '../component/field/TextFieldSimple.tsx';
@@ -117,6 +118,7 @@ function AdminAppeals() {
 
     return (
         <Grid container spacing={2}>
+            <Title>Appeals</Title>
             <Grid xs={12}>
                 <ContainerWithHeader title={'Filters'} iconLeft={<FilterListIcon />} marginTop={2}>
                     <form

--- a/frontend/src/routes/_mod.admin.ban.asn.tsx
+++ b/frontend/src/routes/_mod.admin.ban.asn.tsx
@@ -26,6 +26,7 @@ import { PersonCell } from '../component/PersonCell.tsx';
 import { TableCellRelativeDateField } from '../component/TableCellRelativeDateField.tsx';
 import { TableCellString } from '../component/TableCellString.tsx';
 import { TableHeadingCell } from '../component/TableHeadingCell.tsx';
+import { Title } from '../component/Title.tsx';
 import { Buttons } from '../component/field/Buttons.tsx';
 import { CheckboxSimple } from '../component/field/CheckboxSimple.tsx';
 import { TextFieldSimple } from '../component/field/TextFieldSimple.tsx';
@@ -126,6 +127,7 @@ function AdminBanASN() {
 
     return (
         <Grid container spacing={2}>
+            <Title>Ban ASN</Title>
             <Grid xs={12}>
                 <ContainerWithHeader title={'Filters'} iconLeft={<FilterListIcon />} marginTop={2}>
                     <form

--- a/frontend/src/routes/_mod.admin.ban.cidr.tsx
+++ b/frontend/src/routes/_mod.admin.ban.cidr.tsx
@@ -25,6 +25,7 @@ import { PersonCell } from '../component/PersonCell.tsx';
 import { TableCellRelativeDateField } from '../component/TableCellRelativeDateField.tsx';
 import { TableCellString } from '../component/TableCellString.tsx';
 import { TableHeadingCell } from '../component/TableHeadingCell.tsx';
+import { Title } from '../component/Title';
 import { Buttons } from '../component/field/Buttons.tsx';
 import { CheckboxSimple } from '../component/field/CheckboxSimple.tsx';
 import { TextFieldSimple } from '../component/field/TextFieldSimple.tsx';
@@ -116,6 +117,7 @@ function AdminBanCIDR() {
 
     return (
         <Grid container>
+            <Title>Ban CIDR</Title>
             <Grid xs={12} marginBottom={2}>
                 <ContainerWithHeader title={'Filters'} iconLeft={<FilterListIcon />} marginTop={2}>
                     <form

--- a/frontend/src/routes/_mod.admin.ban.group.tsx
+++ b/frontend/src/routes/_mod.admin.ban.group.tsx
@@ -26,6 +26,7 @@ import { PersonCell } from '../component/PersonCell.tsx';
 import { TableCellRelativeDateField } from '../component/TableCellRelativeDateField.tsx';
 import { TableCellString } from '../component/TableCellString.tsx';
 import { TableHeadingCell } from '../component/TableHeadingCell.tsx';
+import { Title } from '../component/Title';
 import { Buttons } from '../component/field/Buttons.tsx';
 import { CheckboxSimple } from '../component/field/CheckboxSimple.tsx';
 import { TextFieldSimple } from '../component/field/TextFieldSimple.tsx';
@@ -125,6 +126,7 @@ function AdminBanGroup() {
 
     return (
         <Grid container spacing={2}>
+            <Title>Ban Group</Title>
             <Grid xs={12}>
                 <ContainerWithHeader title={'Filters'} iconLeft={<FilterListIcon />}>
                     <form

--- a/frontend/src/routes/_mod.admin.ban.steam.tsx
+++ b/frontend/src/routes/_mod.admin.ban.steam.tsx
@@ -37,6 +37,7 @@ import RouterLink from '../component/RouterLink.tsx';
 import { TableCellBool } from '../component/TableCellBool.tsx';
 import { TableCellRelativeDateField } from '../component/TableCellRelativeDateField.tsx';
 import { TableHeadingCell } from '../component/TableHeadingCell.tsx';
+import { Title } from '../component/Title';
 import { Buttons } from '../component/field/Buttons.tsx';
 import { CheckboxSimple } from '../component/field/CheckboxSimple.tsx';
 import { SelectFieldSimple } from '../component/field/SelectFieldSimple.tsx';
@@ -127,6 +128,7 @@ function AdminBanSteam() {
 
     return (
         <Grid container spacing={2}>
+            <Title>Ban SteamID</Title>
             <Grid xs={12}>
                 <ContainerWithHeader title={'Filters'} iconLeft={<FilterListIcon />} marginTop={2}>
                     <form

--- a/frontend/src/routes/_mod.admin.contests.tsx
+++ b/frontend/src/routes/_mod.admin.contests.tsx
@@ -23,6 +23,7 @@ import { PaginatorLocal } from '../component/PaginatorLocal.tsx';
 import { TableCellBool } from '../component/TableCellBool.tsx';
 import { TableCellString } from '../component/TableCellString.tsx';
 import { TableHeadingCell } from '../component/TableHeadingCell.tsx';
+import { Title } from '../component/Title.tsx';
 import { ModalContestEditor } from '../component/modal';
 import { logErr } from '../util/errors.ts';
 import { commonTableSearchSchema, RowsPerPage } from '../util/table.ts';
@@ -92,6 +93,7 @@ function AdminContests() {
                 </Button>
             ]}
         >
+            <Title>Contests</Title>
             <ContestTable
                 contests={contests ?? []}
                 isLoading={isLoading}

--- a/frontend/src/routes/_mod.admin.filters.tsx
+++ b/frontend/src/routes/_mod.admin.filters.tsx
@@ -43,6 +43,7 @@ import { TableCellBool } from '../component/TableCellBool.tsx';
 import { TableCellSmall } from '../component/TableCellSmall.tsx';
 import { TableCellString } from '../component/TableCellString.tsx';
 import { TableHeadingCell } from '../component/TableHeadingCell.tsx';
+import { Title } from '../component/Title';
 import { ModalConfirm, ModalFilterEditor } from '../component/modal';
 import { useUserFlashCtx } from '../hooks/useUserFlashCtx.ts';
 import { findSelectedRow } from '../util/findSelectedRow.ts';
@@ -151,6 +152,7 @@ function AdminFilters() {
 
     return (
         <Grid container spacing={2}>
+            <Title>Filtered Words</Title>
             <Grid xs={12}>
                 <ContainerWithHeaderAndButtons
                     title={`Word Filters ${Object.values(rowSelection).length ? `Selected: ${Object.values(rowSelection).length}` : ''}`}

--- a/frontend/src/routes/_mod.admin.network.cidrblocks.tsx
+++ b/frontend/src/routes/_mod.admin.network.cidrblocks.tsx
@@ -32,6 +32,7 @@ import { ContainerWithHeaderAndButtons } from '../component/ContainerWithHeaderA
 import { DataTable } from '../component/DataTable.tsx';
 import { PersonCell } from '../component/PersonCell.tsx';
 import { TableHeadingCell } from '../component/TableHeadingCell.tsx';
+import { Title } from '../component/Title';
 import { VCenterBox } from '../component/VCenterBox.tsx';
 import {
     ModalCIDRBlockEditor,
@@ -235,6 +236,7 @@ function AdminNetworkCIDRBlocks() {
 
     return (
         <Stack spacing={2}>
+            <Title>Admin Network CIDR</Title>
             <ContainerWithHeaderAndButtons
                 title="Admin Network CIDR"
                 iconLeft={<WifiOffIcon />}

--- a/frontend/src/routes/_mod.admin.network.index.tsx
+++ b/frontend/src/routes/_mod.admin.network.index.tsx
@@ -4,6 +4,7 @@ import Typography from '@mui/material/Typography';
 import Grid from '@mui/material/Unstable_Grid2';
 import Box from '@mui/system/Box';
 import { createFileRoute } from '@tanstack/react-router';
+import { Title } from '../component/Title';
 
 export const Route = createFileRoute('/_mod/admin/network/')({
     component: AdminNetwork
@@ -12,6 +13,7 @@ export const Route = createFileRoute('/_mod/admin/network/')({
 function AdminNetwork() {
     return (
         <Grid container spacing={2}>
+            <Title>IP History</Title>
             <Grid xs={6} md={6}>
                 <Link href={`/admin/network/ip_hist`}>
                     <Paper component={Box} padding={2}>

--- a/frontend/src/routes/_mod.admin.network.ipInfo.tsx
+++ b/frontend/src/routes/_mod.admin.network.ipInfo.tsx
@@ -19,6 +19,7 @@ import { z } from 'zod';
 import { apiGetNetworkDetails } from '../api';
 import { ContainerWithHeader } from '../component/ContainerWithHeader.tsx';
 import { LoadingPlaceholder } from '../component/LoadingPlaceholder.tsx';
+import { Title } from '../component/Title';
 import { Buttons } from '../component/field/Buttons.tsx';
 import { TextFieldSimple } from '../component/field/TextFieldSimple.tsx';
 import { getFlagEmoji } from '../util/emoji.ts';
@@ -90,6 +91,7 @@ function AdminNetworkInfo() {
     };
     return (
         <Grid container spacing={2}>
+            <Title>IP Info</Title>
             <Grid xs={12}>
                 <ContainerWithHeader title={'Filters'} iconLeft={<FilterListIcon />} marginTop={2}>
                     <form

--- a/frontend/src/routes/_mod.admin.network.iphist.tsx
+++ b/frontend/src/routes/_mod.admin.network.iphist.tsx
@@ -10,6 +10,7 @@ import { apiGetConnections } from '../api';
 import { ContainerWithHeader } from '../component/ContainerWithHeader';
 import { IPHistoryTable } from '../component/IPHistoryTable.tsx';
 import { Paginator } from '../component/Paginator.tsx';
+import { Title } from '../component/Title';
 import { Buttons } from '../component/field/Buttons.tsx';
 import { SteamIDField } from '../component/field/SteamIDField.tsx';
 import { commonTableSearchSchema, RowsPerPage } from '../util/table.ts';
@@ -65,6 +66,7 @@ function AdminNetworkPlayerIPHistory() {
 
     return (
         <Grid container spacing={2}>
+            <Title>Player IP History</Title>
             <Grid xs={12}>
                 <ContainerWithHeader title={'Filters'} iconLeft={<FilterListIcon />} marginTop={2}>
                     <form

--- a/frontend/src/routes/_mod.admin.network.playersbyip.tsx
+++ b/frontend/src/routes/_mod.admin.network.playersbyip.tsx
@@ -16,6 +16,7 @@ import { DataTable } from '../component/DataTable.tsx';
 import { Paginator } from '../component/Paginator.tsx';
 import RouterLink from '../component/RouterLink.tsx';
 import { TableHeadingCell } from '../component/TableHeadingCell.tsx';
+import { Title } from '../component/Title';
 import { Buttons } from '../component/field/Buttons.tsx';
 import { TextFieldSimple } from '../component/field/TextFieldSimple.tsx';
 import { commonTableSearchSchema, LazyResult, RowsPerPage } from '../util/table.ts';
@@ -98,6 +99,7 @@ function AdminNetworkPlayersByCIDR() {
 
     return (
         <Grid container spacing={2}>
+            <Title>Players by IP</Title>
             <Grid xs={12}>
                 <ContainerWithHeader title={'Filters'} iconLeft={<FilterListIcon />} marginTop={2}>
                     <form

--- a/frontend/src/routes/_mod.admin.news.tsx
+++ b/frontend/src/routes/_mod.admin.news.tsx
@@ -17,6 +17,7 @@ import { apiNewsSave, NewsEntry } from '../api/news.ts';
 import { MarkDownRenderer } from '../component/MarkdownRenderer.tsx';
 import { NewsList } from '../component/NewsList.tsx';
 import { TabPanel } from '../component/TabPanel.tsx';
+import { Title } from '../component/Title';
 import { useUserFlashCtx } from '../hooks/useUserFlashCtx.ts';
 import { logErr } from '../util/errors.ts';
 
@@ -53,6 +54,7 @@ function AdminNews() {
 
     return (
         <Grid container spacing={2}>
+            <Title>Edit News</Title>
             <Grid xs={8}>
                 <Paper elevation={1}>
                     <Stack spacing={3} padding={3}>

--- a/frontend/src/routes/_mod.admin.people.tsx
+++ b/frontend/src/routes/_mod.admin.people.tsx
@@ -19,6 +19,7 @@ import { DataTable } from '../component/DataTable.tsx';
 import { Paginator } from '../component/Paginator.tsx';
 import { PersonCell } from '../component/PersonCell.tsx';
 import { TableHeadingCell } from '../component/TableHeadingCell.tsx';
+import { Title } from '../component/Title';
 import { Buttons } from '../component/field/Buttons.tsx';
 import { CheckboxSimple } from '../component/field/CheckboxSimple.tsx';
 import { SteamIDField } from '../component/field/SteamIDField.tsx';
@@ -99,6 +100,7 @@ function AdminPeople() {
 
     return (
         <Grid container spacing={2}>
+            <Title>People</Title>
             <Grid xs={12}>
                 <ContainerWithHeader title={'Filters'} iconLeft={<FilterListIcon />} marginTop={2}>
                     <form

--- a/frontend/src/routes/_mod.admin.reports.tsx
+++ b/frontend/src/routes/_mod.admin.reports.tsx
@@ -34,6 +34,7 @@ import { PaginatorLocal } from '../component/PaginatorLocal.tsx';
 import { PersonCell } from '../component/PersonCell.tsx';
 import RouterLink from '../component/RouterLink.tsx';
 import { TableHeadingCell } from '../component/TableHeadingCell.tsx';
+import { Title } from '../component/Title';
 import { Buttons } from '../component/field/Buttons.tsx';
 import { SelectFieldSimple } from '../component/field/SelectFieldSimple.tsx';
 import { TextFieldSimple } from '../component/field/TextFieldSimple.tsx';
@@ -119,6 +120,7 @@ function AdminReports() {
 
     return (
         <Grid container spacing={2}>
+            <Title>Reports</Title>
             <Grid xs={12}>
                 <ContainerWithHeader title={'Filters'} iconLeft={<FilterListIcon />} marginTop={2}>
                     <form

--- a/frontend/src/routes/_mod.admin.votes.tsx
+++ b/frontend/src/routes/_mod.admin.votes.tsx
@@ -16,6 +16,7 @@ import { Paginator } from '../component/Paginator.tsx';
 import { PersonCell } from '../component/PersonCell.tsx';
 import { TableCellBool } from '../component/TableCellBool.tsx';
 import { TableHeadingCell } from '../component/TableHeadingCell.tsx';
+import { Title } from '../component/Title';
 import { Buttons } from '../component/field/Buttons.tsx';
 import { TextFieldSimple } from '../component/field/TextFieldSimple.tsx';
 import { commonTableSearchSchema, LazyResult, RowsPerPage } from '../util/table.ts';
@@ -77,6 +78,7 @@ function AdminVotes() {
 
     return (
         <Grid container spacing={2}>
+            <Title>Votes</Title>
             <Grid xs={12}>
                 <ContainerWithHeader title={'Filters'} iconLeft={<FilterListIcon />} marginTop={2}>
                     <form

--- a/frontend/src/util/text.tsx
+++ b/frontend/src/util/text.tsx
@@ -90,3 +90,8 @@ type avatarSize = 'small' | 'medium' | 'full';
 export const avatarHashToURL = (hash?: string, size: avatarSize = 'full') => {
     return `https://avatars.steamstatic.com/${hash ?? defaultAvatarHash}${size == 'small' ? '' : `_${size}`}.jpg`;
 };
+
+export const toTitleCase = (string: string) => {
+    const titleCaseWord = (s: string) => s[0].toUpperCase() + s.slice(1);
+    return string.replace(/\w\S*/g, titleCaseWord);
+};


### PR DESCRIPTION
Fixes #482 

Updates all route files except these:
```
src/routes/_auth.permission.tsx
src/routes/_mod.tsx
src/routes/_auth.logout.tsx
src/routes/_guest.login.index.tsx
src/routes/__root.tsx
src/routes/_auth.login.discord.tsx
src/routes/_guest.login.success.tsx
src/routes/_admin.tsx
src/routes/_guest.patreon.tsx
src/routes/_guest.index.tsx
src/routes/_auth.page-not-found.tsx
src/routes/_guest.tsx
src/routes/_auth.tsx
```

Tested by browsing around most of the pages -- but I don't have data in my local DB so I couldn't hit all of them. No new type errors introduced.