### PR TITLE
Apply word filtering rules to usernames on player connect

### DIFF
--- a/frontend/src/api/bans.ts
+++ b/frontend/src/api/bans.ts
@@ -66,7 +66,8 @@ export enum BanReason {
     Profile = 10,
     ItemDescriptions = 11,
     BotHost = 12,
-    Evading = 13
+    Evading = 13,
+    Username = 14
 }
 
 export enum Duration {
@@ -114,7 +115,8 @@ export const BanReasons: Record<BanReason, string> = {
     [BanReason.Profile]: 'Inappropriate Steam Profile',
     [BanReason.ItemDescriptions]: 'Item Name/Descriptions',
     [BanReason.BotHost]: 'Bot Host',
-    [BanReason.Evading]: 'Evading'
+    [BanReason.Evading]: 'Evading',
+    [BanReason.Username]: 'Inappropriate Username'
 };
 
 export const banReasonsCollection = [
@@ -130,7 +132,8 @@ export const banReasonsCollection = [
     BanReason.External,
     BanReason.Custom,
     BanReason.BotHost,
-    BanReason.Evading
+    BanReason.Evading,
+    BanReason.Username
 ];
 
 export enum BanType {

--- a/internal/chat/chat_repository.go
+++ b/internal/chat/chat_repository.go
@@ -76,16 +76,6 @@ func (r chatRepository) handleMessage(ctx context.Context, evt logparse.ServerEv
 	}
 
 	go func(userMsg domain.PersonMessage) {
-		if userMsg.ServerName == "localhost-1" {
-			slog.Debug("Chat message",
-				slog.Int64("id", userMsg.PersonMessageID),
-				slog.String("server", evt.ServerName),
-				slog.String("name", person.Name),
-				slog.String("steam_id", person.SID.String()),
-				slog.Bool("team", userMsg.Team),
-				slog.String("message", userMsg.Body))
-		}
-
 		matchedFilter := r.wordFilterUsecase.Check(userMsg.Body)
 		if len(matchedFilter) > 0 {
 			if errSaveMatch := r.wordFilterUsecase.AddMessageFilterMatch(ctx, userMsg.PersonMessageID, matchedFilter[0].FilterID); errSaveMatch != nil {

--- a/internal/domain/chat.go
+++ b/internal/domain/chat.go
@@ -9,6 +9,7 @@ type ChatRepository interface {
 	AddChatHistory(ctx context.Context, message *PersonMessage) error
 	QueryChatHistory(ctx context.Context, filters ChatHistoryQueryFilter) ([]QueryChatHistoryResult, error)
 	GetPersonMessageContext(ctx context.Context, serverID int, messageID int64, paddedMessageCount int) ([]QueryChatHistoryResult, error)
+	GetWarningChan() chan NewUserWarning
 }
 
 type ChatUsecase interface {

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -77,6 +77,7 @@ const (
 	ItemDescriptions
 	BotHost
 	Evading
+	Username
 )
 
 func (r Reason) String() string {
@@ -94,6 +95,7 @@ func (r Reason) String() string {
 		ItemDescriptions: "Item Name or Descriptions",
 		BotHost:          "BotHost",
 		Evading:          "Evading",
+		Username:         "Inappropriate Username",
 	}[r]
 }
 

--- a/internal/domain/person.go
+++ b/internal/domain/person.go
@@ -329,6 +329,7 @@ type UserWarning struct {
 
 type NewUserWarning struct {
 	UserMessage PersonMessage
+	PlayerID    int
 	UserWarning
 }
 

--- a/internal/domain/state.go
+++ b/internal/domain/state.go
@@ -25,6 +25,7 @@ type StateUsecase interface {
 	FindByName(name string) []PlayerServerInfo
 	FindBySteamID(steamID steamid.SteamID) []PlayerServerInfo
 	Kick(ctx context.Context, target steamid.SteamID, reason Reason) error
+	KickPlayerID(ctx context.Context, targetPlayerID int, targetServerID int, reason Reason) error
 	LogAddressAdd(ctx context.Context, logAddress string)
 	OnFindExec(ctx context.Context, name string, steamID steamid.SteamID, ip net.IP, cidr *net.IPNet, onFoundCmd func(info PlayerServerInfo) string) error
 	PSay(ctx context.Context, target steamid.SteamID, message string) error

--- a/internal/state/state_usecase.go
+++ b/internal/state/state_usecase.go
@@ -354,6 +354,13 @@ func (s *stateUsecase) Kick(ctx context.Context, target steamid.SteamID, reason 
 	return nil
 }
 
+// Kick will kick the steam id from whatever server it is connected to.
+func (s *stateUsecase) KickPlayerID(ctx context.Context, targetPlayerID int, targetServerID int, reason domain.Reason) error {
+	_, err := s.ExecServer(ctx, targetServerID, fmt.Sprintf("sm_kick #%d %s", targetPlayerID, reason.String()))
+
+	return err
+}
+
 // Silence will gag & mute a player.
 func (s *stateUsecase) Silence(ctx context.Context, target steamid.SteamID, reason domain.Reason,
 ) error {

--- a/internal/wordfilter/wordfilter_repository.go
+++ b/internal/wordfilter/wordfilter_repository.go
@@ -27,8 +27,8 @@ func (r *wordFilterRepository) SaveFilter(ctx context.Context, filter *domain.Fi
 
 func (r *wordFilterRepository) insertFilter(ctx context.Context, filter *domain.Filter) error {
 	const query = `
-		INSERT INTO filtered_word (author_id, pattern, is_regex, is_enabled, trigger_count, created_on, updated_on, action, duration, weight) 
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) 
+		INSERT INTO filtered_word (author_id, pattern, is_regex, is_enabled, trigger_count, created_on, updated_on, action, duration, weight)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
 		RETURNING filter_id`
 
 	if errQuery := r.db.QueryRow(ctx, query, filter.AuthorID.Int64(), filter.Pattern,


### PR DESCRIPTION
Rather than adding much specialized handling I just treat a connect event as a chat message with the player's name in it. This is a bit annoying since it shows up on the site's chat log, but I suppose it could be a good log to protect against users changing their names a lot (in an attempt to hide something offensive). Followups could hide those messages from showing up on the site.

While testing on my server, I realized that automatic actions on chat messages didn't seem to be working at all (maybe I'm missing some setup?). I fixed that here by having chat_usecase listen to chat_repository's WarningChan.

Another new change here is that we kick based off of the server id and player id from the log event instead of doing a lookup by steamid. This is pretty necessary as it's very unlikely we'll have gotten a status update from the server before the connect event... This also fixes an issue where users could avoid auto-kicks for chat messages if they said something offensive very shortly after joining a server.

There's a small loophole, that we don't check usernames continuously... So if an offensive username joins while the gbans server is restarting they'll get to stay in the server.

Fixes #435 