### PR TITLE
Allow configuring center_projectiles clientpref from site settings

### DIFF
--- a/frontend/src/api/profile.ts
+++ b/frontend/src/api/profile.ts
@@ -284,7 +284,7 @@ export interface PersonSettings extends TimeStamped {
     forum_signature: string;
     forum_profile_messages: boolean;
     stats_hidden: boolean;
-    center_projectiles?: boolean;
+    center_projectiles: boolean;
 }
 
 export const apiGetPersonSettings = async (abortController?: AbortController) => {

--- a/frontend/src/api/profile.ts
+++ b/frontend/src/api/profile.ts
@@ -284,6 +284,7 @@ export interface PersonSettings extends TimeStamped {
     forum_signature: string;
     forum_profile_messages: boolean;
     stats_hidden: boolean;
+    center_projectiles?: boolean;
 }
 
 export const apiGetPersonSettings = async (abortController?: AbortController) => {
@@ -296,13 +297,14 @@ export const apiSavePersonSettings = async (
     forum_signature: string,
     forum_profile_messages: boolean,
     stats_hidden: boolean,
+    center_projectiles: boolean,
     abortController?: AbortController
 ) => {
     return transformTimeStampedDates(
         await apiCall<PersonSettings>(
             `/api/current_profile/settings`,
             'POST',
-            { forum_signature, forum_profile_messages, stats_hidden },
+            { forum_signature, forum_profile_messages, stats_hidden, center_projectiles },
             abortController
         )
     );

--- a/frontend/src/routes/_auth.settings.tsx
+++ b/frontend/src/routes/_auth.settings.tsx
@@ -61,9 +61,11 @@ interface SettingsValues {
     forum_signature: string;
     forum_profile_messages: boolean;
     stats_hidden: boolean;
+    center_projectiles: boolean;
 }
 
 type userSettingTabs = 'general' | 'connections' | 'forums';
+
 
 function ProfileSettings() {
     const { sendFlash } = useUserFlashCtx();
@@ -79,7 +81,8 @@ function ProfileSettings() {
             return await apiSavePersonSettings(
                 values.forum_signature,
                 values.forum_profile_messages,
-                values.stats_hidden
+                values.stats_hidden,
+                values.center_projectiles ?? false
             );
         },
         onSuccess: async () => {

--- a/frontend/src/routes/_auth.settings.tsx
+++ b/frontend/src/routes/_auth.settings.tsx
@@ -7,6 +7,7 @@ import ForumIcon from '@mui/icons-material/Forum';
 import LoginIcon from '@mui/icons-material/Login';
 import SettingsIcon from '@mui/icons-material/Settings';
 import SettingsInputComponentIcon from '@mui/icons-material/SettingsInputComponent';
+import SportsEsportsIcon from '@mui/icons-material/SportsEsports';
 import Avatar from '@mui/material/Avatar';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
@@ -41,7 +42,7 @@ import { useUserFlashCtx } from '../hooks/useUserFlashCtx.ts';
 import { SubHeading, TabButton, TabSection } from './_admin.admin.settings.tsx';
 
 const settingsSchema = z.object({
-    section: z.enum(['general', 'forums', 'connections']).optional().default('general')
+    section: z.enum(['general', 'forums', 'connections', 'game']).optional().default('general')
 });
 
 export const Route = createFileRoute('/_auth/settings')({
@@ -64,8 +65,7 @@ interface SettingsValues {
     center_projectiles: boolean;
 }
 
-type userSettingTabs = 'general' | 'connections' | 'forums';
-
+type userSettingTabs = 'general' | 'connections' | 'forums' | 'game';
 
 function ProfileSettings() {
     const { sendFlash } = useUserFlashCtx();
@@ -113,6 +113,13 @@ function ProfileSettings() {
                                 currentTab={tab}
                                 label={'General'}
                             />
+                            <TabButton
+                                tab={'game'}
+                                onClick={onTabClick}
+                                icon={<SportsEsportsIcon />}
+                                currentTab={tab}
+                                label={'Gameplay'}
+                            />
                             {hasPermission(PermissionLevel.Moderator) && (
                                 <TabButton
                                     tab={'forums'}
@@ -134,6 +141,7 @@ function ProfileSettings() {
                         </Stack>
                     </Grid>
                     <GeneralSection tab={tab} settings={settings} mutate={mutation.mutate} />
+                    <GameplaySection tab={tab} settings={settings} mutate={mutation.mutate} />
                     {hasPermission(PermissionLevel.Moderator) && (
                         <ForumSection tab={tab} settings={settings} mutate={mutation.mutate} />
                     )}
@@ -194,6 +202,62 @@ const GeneralSection = ({
                             }}
                         />
                         <SubHeading>It is still viewable by yourself.</SubHeading>
+                    </Grid>
+
+                    <Grid xs={12}>
+                        <Subscribe
+                            selector={(state) => [state.canSubmit, state.isSubmitting]}
+                            children={([canSubmit, isSubmitting]) => (
+                                <Buttons reset={reset} canSubmit={canSubmit} isSubmitting={isSubmitting} />
+                            )}
+                        />
+                    </Grid>
+                </Grid>
+            </form>
+        </TabSection>
+    );
+};
+
+const GameplaySection = ({
+    tab,
+    settings,
+    mutate
+}: {
+    tab: userSettingTabs;
+    settings: PersonSettings;
+    mutate: (s: PersonSettings) => void;
+}) => {
+    const { Field, Subscribe, handleSubmit, reset } = useForm({
+        onSubmit: async ({ value }) => {
+            mutate({ ...settings, ...value });
+        },
+        validatorAdapter: zodValidator,
+        defaultValues: {
+            center_projectiles: settings.center_projectiles ?? false
+        }
+    });
+
+    return (
+        <TabSection tab={'game'} currentTab={tab} label={'Gameplay'} description={'Configure your in-game clientprefs'}>
+            <form
+                onSubmit={async (e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    await handleSubmit();
+                }}
+            >
+                <Grid container spacing={2}>
+                    <Grid xs={12}>
+                        <Field
+                            name={'center_projectiles'}
+                            validators={{
+                                onChange: z.boolean()
+                            }}
+                            children={(props) => {
+                                return <CheckboxSimple {...props} label={'Use center projectiles'} />;
+                            }}
+                        />
+                        <SubHeading>Applies to all projectile weapons</SubHeading>
                     </Grid>
 
                     <Grid xs={12}>

--- a/internal/cmd/net.go
+++ b/internal/cmd/net.go
@@ -68,7 +68,7 @@ func netUpdateCmd() *cobra.Command {
 
 			eventBroadcaster := fp.NewBroadcaster[logparse.EventType, logparse.ServerEvent]()
 
-			personUsecase := person.NewPersonUsecase(person.NewPersonRepository(dbUsecase), configUsecase)
+			personUsecase := person.NewPersonUsecase(person.NewPersonRepository(conf, dbUsecase), configUsecase)
 
 			if errUpdate := ip2location.Update(ctx, conf.GeoLocation.CachePath, conf.GeoLocation.Token); errUpdate != nil {
 				slog.Error("Failed to update", log.ErrAttr(errUpdate))

--- a/internal/cmd/refresh.go
+++ b/internal/cmd/refresh.go
@@ -96,7 +96,7 @@ func refreshFiltersCmd() *cobra.Command {
 
 			discordUsecase := discord.NewDiscordUsecase(discordRepository, wordFilterUsecase)
 
-			personUsecase := person.NewPersonUsecase(person.NewPersonRepository(dbUsecase), configUsecase)
+			personUsecase := person.NewPersonUsecase(person.NewPersonRepository(conf, dbUsecase), configUsecase)
 			reportUsecase := report.NewReportUsecase(report.NewReportRepository(dbUsecase), discordUsecase, configUsecase, personUsecase, nil)
 			// banGroupUsecase := steamgroup.NewBanGroupUsecase(steamgroup.NewSteamGroupRepository(dbUsecase), personUsecase)
 			networkUsecase := network.NewNetworkUsecase(eventBroadcaster, network.NewNetworkRepository(dbUsecase), personUsecase)

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -145,7 +145,7 @@ func serveCmd() *cobra.Command { //nolint:maintidx
 			//	return
 			// }
 
-			personUsecase := person.NewPersonUsecase(person.NewPersonRepository(dbUsecase), configUsecase)
+			personUsecase := person.NewPersonUsecase(person.NewPersonRepository(conf, dbUsecase), configUsecase)
 
 			networkUsecase := network.NewNetworkUsecase(eventBroadcaster, network.NewNetworkRepository(dbUsecase), personUsecase)
 			go networkUsecase.Start(ctx)

--- a/internal/cmd/setup.go
+++ b/internal/cmd/setup.go
@@ -76,7 +76,7 @@ func setupCmd() *cobra.Command {
 
 			serversUsecase := servers.NewServersUsecase(servers.NewServersRepository(dbUsecase))
 			stateUsecase := state.NewStateUsecase(broadcaster, state.NewStateRepository(state.NewCollector(serversUsecase)), configUsecase, serversUsecase)
-			personUsecase := person.NewPersonUsecase(person.NewPersonRepository(dbUsecase), configUsecase)
+			personUsecase := person.NewPersonUsecase(person.NewPersonRepository(conf, dbUsecase), configUsecase)
 
 			assetRepo := asset.NewLocalRepository(dbUsecase, configUsecase)
 			if errAssetInit := assetRepo.Init(ctx); errAssetInit != nil {

--- a/internal/database/migrations/000095_add_centerprojectiles.down.sql
+++ b/internal/database/migrations/000095_add_centerprojectiles.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+DROP TABLE IF EXISTS sm_cookies_cache;
+DROP TABLE IF EXISTS sm_cookies;
+
+COMMIT;

--- a/internal/database/migrations/000095_add_centerprojectiles.up.sql
+++ b/internal/database/migrations/000095_add_centerprojectiles.up.sql
@@ -1,0 +1,22 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS sm_cookies
+(
+    id serial,
+    name varchar(30) NOT NULL UNIQUE,
+    description varchar(255),
+    access INTEGER,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS sm_cookie_cache
+(
+    player varchar(65) NOT NULL,
+    cookie_id int NOT NULL,
+    value varchar(100),
+    timestamp int NOT NULL,
+    PRIMARY KEY (player, cookie_id)
+);
+
+
+COMMIT;

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -56,6 +56,7 @@ type Config struct {
 	Demo        ConfigDemo        `json:"demo"`
 	Filters     ConfigFilter      `json:"filters"`
 	Discord     ConfigDiscord     `json:"discord"`
+	Clientprefs ConfigClientprefs `mapstructure:"clientprefs"`
 	Log         ConfigLog         `json:"log"`
 	GeoLocation ConfigIP2Location `json:"geo_location"`
 	Debug       ConfigDebug       `json:"debug"`
@@ -110,6 +111,10 @@ type ConfigDB struct {
 	DSN         string `mapstructure:"dsn"`
 	AutoMigrate bool   `mapstructure:"auto_migrate"`
 	LogQueries  bool   `mapstructure:"log_queries"`
+}
+
+type ConfigClientprefs struct {
+	CenterProjectiles bool `mapstructure:"center_projectiles"`
 }
 
 type ConfigPatreon struct {

--- a/internal/domain/person.go
+++ b/internal/domain/person.go
@@ -305,14 +305,20 @@ type PersonSettings struct {
 	ForumSignature       string          `json:"forum_signature"`
 	ForumProfileMessages bool            `json:"forum_profile_messages"`
 	StatsHidden          bool            `json:"stats_hidden"`
-	CreatedOn            time.Time       `json:"created_on"`
-	UpdatedOn            time.Time       `json:"updated_on"`
+
+	// This key will be absent to indicate that this feature
+	// is disabled (and UI should not be shown to the user).
+	CenterProjectiles *bool `json:"center_projectiles,omitempty"`
+
+	CreatedOn time.Time `json:"created_on"`
+	UpdatedOn time.Time `json:"updated_on"`
 }
 
 type PersonSettingsUpdate struct {
 	ForumSignature       string `json:"forum_signature"`
 	ForumProfileMessages bool   `json:"forum_profile_messages"`
 	StatsHidden          bool   `json:"stats_hidden"`
+	CenterProjectiles    *bool  `json:"center_projectiles,omitempty"`
 }
 
 type UserWarning struct {

--- a/internal/person/person_usecase.go
+++ b/internal/person/person_usecase.go
@@ -275,6 +275,7 @@ func (u personUsecase) SavePersonSettings(ctx context.Context, user domain.Perso
 	settings.ForumProfileMessages = update.ForumProfileMessages
 	settings.StatsHidden = update.StatsHidden
 	settings.ForumSignature = util.SanitizeUGC(update.ForumSignature)
+	settings.CenterProjectiles = update.CenterProjectiles
 
 	if errSave := u.personRepo.SavePersonSettings(ctx, &settings); errSave != nil {
 		return settings, errSave


### PR DESCRIPTION
Part of #373 

Allows configuring tf2centerprojectiles from the user settings page.

The visual UI changes and new DB queries are both gated behind a new config flag, as this requires some annoying sourcemod setup... we may need some amendments to this if you are segmenting your sourcemod tables in a different db schema.

The queries are a bit icky but are intended to be easy to add support for more clientprefs down the line (ie #520)

Tested: with the new config flag disabled, the settings page looks the same as on master. With the new config flag, there is a new accordion+checkbox which reads/updates the sm_cookie_cache table correctly. Updating the setting then joining a server results in the client getting the new setting.

----

Clientprefs sql init does create an SQL function [for updating cookies](https://github.com/alliedmodders/sourcemod/blob/4e73713fabedaa39848b7b4f85700990d519b55f/configs/sql-init-scripts/pgsql/clientprefs-pgsql.sql#L21). I avoided it because A) my query seems simpler and maybe  faster when updating multiple cookies and B) there is no similar function for reading cookie values, so we have to interact with the tables directly anyways.

My biggest annoyance with this feature is that sourcemod caches cookies locally and delays writing updates to cookies. So a user who is ingame won't see a change to the website take effect right away. And trying to change the same setting ingame+on the website at the same time will be full of race conditions.