### PR TITLE
Drop /set_steam

### DIFF
--- a/internal/config/config_usecase.go
+++ b/internal/config/config_usecase.go
@@ -110,7 +110,7 @@ func ReadStaticConfig() (domain.StaticConfig, error) {
 		return config, fmt.Errorf("%w: %s", domain.ErrInvalidConfig, "database_dsn")
 	}
 
-	if len(config.SteamKey) == 32 {
+	if len(config.SteamKey) != 32 {
 		return config, fmt.Errorf("%w: %s", domain.ErrInvalidConfig, "steam_key")
 	}
 

--- a/internal/config/helper.go
+++ b/internal/config/helper.go
@@ -50,6 +50,7 @@ func setDefaultConfigValues() {
 	defaultConfig := map[string]any{
 		"owner":                 "",
 		"external_url":          "",
+		"steam_key":             "",
 		"http_host":             "127.0.0.1",
 		"http_port":             6006,
 		"http_static_path":      "frontend/dist",

--- a/internal/discord/discord_repository.go
+++ b/internal/discord/discord_repository.go
@@ -450,16 +450,6 @@ func (bot *discordRepository) botRegisterSlashCommands(appID string) error {
 		},
 		{
 			ApplicationID:            appID,
-			Name:                     string(domain.CmdSetSteam),
-			DMPermission:             &dmPerms,
-			DefaultMemberPermissions: &modPerms,
-			Description:              "Set your steam ID so gbans can link your account to discord",
-			Options: []*discordgo.ApplicationCommandOption{
-				optUserID,
-			},
-		},
-		{
-			ApplicationID:            appID,
 			Name:                     string(domain.CmdHistory),
 			DMPermission:             &dmPerms,
 			DefaultMemberPermissions: &modPerms,

--- a/internal/discord/discord_repository.go
+++ b/internal/discord/discord_repository.go
@@ -303,7 +303,8 @@ func (bot *discordRepository) botRegisterSlashCommands(appID string) error {
 
 	reasonCollection := []domain.Reason{
 		domain.External, domain.Cheating, domain.Racism, domain.Harassment, domain.Exploiting,
-		domain.WarningsExceeded, domain.Spam, domain.Language, domain.Profile, domain.ItemDescriptions, domain.BotHost, domain.Custom,
+		domain.WarningsExceeded, domain.Spam, domain.Language, domain.Profile, domain.ItemDescriptions,
+		domain.BotHost, domain.Evading, domain.Username, domain.Custom,
 	}
 
 	reasons := make([]*discordgo.ApplicationCommandOptionChoice, len(reasonCollection))

--- a/internal/discord/discord_service.go
+++ b/internal/discord/discord_service.go
@@ -70,13 +70,12 @@ func (h discordService) Start(_ context.Context) {
 		domain.CmdLogs:    h.makeOnLogs(),
 		domain.CmdMute:    h.makeOnMute(),
 		// domain.CmdCheckIP:  h.onCheckIp,
-		domain.CmdPlayers:  h.makeOnPlayers(),
-		domain.CmdPSay:     h.makeOnPSay(),
-		domain.CmdSay:      h.makeOnSay(),
-		domain.CmdServers:  h.makeOnServers(),
-		domain.CmdSetSteam: h.makeOnSetSteam(),
-		domain.CmdUnban:    h.makeOnUnban(),
-		domain.CmdStats:    h.makeOnStats(),
+		domain.CmdPlayers: h.makeOnPlayers(),
+		domain.CmdPSay:    h.makeOnPSay(),
+		domain.CmdSay:     h.makeOnSay(),
+		domain.CmdServers: h.makeOnServers(),
+		domain.CmdUnban:   h.makeOnUnban(),
+		domain.CmdStats:   h.makeOnStats(),
 	}
 
 	for k, v := range cmdMap {
@@ -263,26 +262,6 @@ func (h discordService) onHistoryIP(ctx context.Context, _ *discordgo.Session, i
 //	embed.Description = strings.Join(lines, "\n")
 //	return nil
 // }
-
-func (h discordService) makeOnSetSteam() func(_ context.Context, _ *discordgo.Session, _ *discordgo.InteractionCreate) (*discordgo.MessageEmbed, error) {
-	return func(ctx context.Context, _ *discordgo.Session,
-		interaction *discordgo.InteractionCreate,
-	) (*discordgo.MessageEmbed, error) {
-		opts := domain.OptionMap(interaction.ApplicationCommandData().Options)
-
-		steamID, errResolveSID := steamid.Resolve(ctx, opts[domain.OptUserIdentifier].StringValue())
-		if errResolveSID != nil || !steamID.Valid() {
-			return nil, domain.ErrInvalidSID
-		}
-
-		errSetSteam := h.persons.SetSteam(ctx, steamID, interaction.Member.User.ID)
-		if errSetSteam != nil {
-			return nil, errSetSteam
-		}
-
-		return SetSteamMessage(), nil
-	}
-}
 
 func (h discordService) onUnbanSteam(ctx context.Context, _ *discordgo.Session, interaction *discordgo.InteractionCreate) (*discordgo.MessageEmbed, error) {
 	opts := domain.OptionMap(interaction.ApplicationCommandData().Options[0].Options)

--- a/internal/discord/responses.go
+++ b/internal/discord/responses.go
@@ -785,6 +785,10 @@ func ServersMessage(currentStateRegion map[string][]domain.ServerState, serversU
 		var counts []string
 
 		for _, curState := range currentStateRegion[region] {
+			if !curState.Enabled {
+				continue
+			}
+
 			_, ok := stats[region]
 			if !ok {
 				stats[region] = 0

--- a/internal/domain/discord.go
+++ b/internal/domain/discord.go
@@ -105,7 +105,6 @@ const (
 	CmdCSay        Cmd = "csay"
 	CmdSay         Cmd = "say"
 	CmdServers     Cmd = "servers"
-	CmdSetSteam    Cmd = "set_steam"
 	CmdStats       Cmd = "stats"
 	CmdStatsGlobal Cmd = "global"
 	CmdStatsPlayer Cmd = "player"

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -47,7 +47,7 @@ var (
 	ErrLoadServer               = errors.New("failed to load match server")
 	ErrMissingParam             = errors.New("failed to request at least one required parameter")
 	ErrBanDoesNotExist          = errors.New("ban does not exist")
-	ErrSteamUnset               = errors.New("must set steam id. see /set_steam command")
+	ErrSteamUnset               = errors.New("must connect discord, see connections in your settings page to connect it")
 	ErrFetchClassStats          = errors.New("failed to fetch class stats")
 	ErrFetchWeaponStats         = errors.New("failed to fetch weapon stats")
 	ErrFetchKillstreakStats     = errors.New("failed to fetch killstreak stats")

--- a/internal/domain/state.go
+++ b/internal/domain/state.go
@@ -58,6 +58,7 @@ type ServerConfig struct {
 	DefaultHostname string
 	Host            string
 	Port            int
+	Enabled         bool
 	RconPassword    string
 	ReservedSlots   int
 	CC              string


### PR DESCRIPTION
Removes the no longer necessary and bad /set_steam command. Users will need to connect their accounts under their settings instead.

closes #560 