### PR TITLE
Cleanup orphaned demos

### DIFF
--- a/internal/asset/asset_repository_local.go
+++ b/internal/asset/asset_repository_local.go
@@ -36,7 +36,7 @@ func (l localRepository) Put(ctx context.Context, asset domain.Asset, body io.Re
 		return domain.Asset{}, errExisting
 	}
 
-	outPath, errOutPath := l.genAssetPath(asset.HashString())
+	outPath, errOutPath := l.GenAssetPath(asset.HashString())
 	if errOutPath != nil {
 		return domain.Asset{}, errOutPath
 	}
@@ -84,7 +84,7 @@ func (l localRepository) Delete(ctx context.Context, assetID uuid.UUID) (int64, 
 		return 0, l.db.DBErr(errExec)
 	}
 
-	assetPath, errAssetPath := l.genAssetPath(asset.HashString())
+	assetPath, errAssetPath := l.GenAssetPath(asset.HashString())
 	if errAssetPath != nil {
 		return 0, errAssetPath
 	}
@@ -115,7 +115,7 @@ func (l localRepository) Get(ctx context.Context, assetID uuid.UUID) (domain.Ass
 		return domain.Asset{}, nil, errAsset
 	}
 
-	assetPath, errAssetPath := l.genAssetPath(asset.HashString())
+	assetPath, errAssetPath := l.GenAssetPath(asset.HashString())
 	if errAssetPath != nil {
 		return domain.Asset{}, nil, errAssetPath
 	}
@@ -128,7 +128,7 @@ func (l localRepository) Get(ctx context.Context, assetID uuid.UUID) (domain.Ass
 	return asset, reader, nil
 }
 
-func (l localRepository) genAssetPath(hash string) (string, error) {
+func (l localRepository) GenAssetPath(hash string) (string, error) {
 	if len(hash) < 2 {
 		return "", domain.ErrInvalidParameter
 	}
@@ -169,7 +169,7 @@ func (l localRepository) getAssetByUUID(ctx context.Context, assetID uuid.UUID) 
 
 	asset.AuthorID = steamid.New(authorID)
 
-	assetPath, errAssetPath := l.genAssetPath(asset.HashString())
+	assetPath, errAssetPath := l.GenAssetPath(asset.HashString())
 	if errAssetPath != nil {
 		return domain.Asset{}, errAssetPath
 	}
@@ -202,7 +202,7 @@ func (l localRepository) getAssetByHash(ctx context.Context, hash []byte) (domai
 
 	asset.AuthorID = steamid.New(authorID)
 
-	assetPath, errAssetPath := l.genAssetPath(asset.HashString())
+	assetPath, errAssetPath := l.GenAssetPath(asset.HashString())
 	if errAssetPath != nil {
 		return domain.Asset{}, errAssetPath
 	}

--- a/internal/asset/asset_usecase.go
+++ b/internal/asset/asset_usecase.go
@@ -83,6 +83,10 @@ func (s assets) Delete(ctx context.Context, assetID uuid.UUID) (int64, error) {
 	return size, nil
 }
 
+func (s assets) GenAssetPath(hash string) (string, error) {
+	return s.repository.GenAssetPath(hash)
+}
+
 func generateFileHash(file io.Reader) ([]byte, error) {
 	hasher := sha256.New()
 	if _, err := io.Copy(hasher, file); err != nil {

--- a/internal/demo/demo_respository.go
+++ b/internal/demo/demo_respository.go
@@ -24,7 +24,7 @@ func (r *demoRepository) ExpiredDemos(ctx context.Context, limit uint64) ([]doma
 		Select("d.demo_id", "d.title", "d.asset_id").
 		From("demo d").
 		LeftJoin("report r on d.demo_id = r.demo_id").
-		Where("r.demo_id > 0").
+		Where("d.archive = false").
 		OrderBy("d.demo_id").
 		Offset(limit))
 	if errRow != nil {
@@ -200,6 +200,15 @@ func (r *demoRepository) updateDemo(ctx context.Context, demoFile *domain.DemoFi
 
 	if errExec := r.db.ExecUpdateBuilder(ctx, query); errExec != nil {
 		return r.db.DBErr(errExec)
+	}
+
+	return nil
+}
+
+func (r *demoRepository) Delete(ctx context.Context, demoID int64) error {
+	const query = `DELETE FROM demo WHERE demo_id = $1`
+	if err := r.db.Exec(ctx, query, demoID); err != nil {
+		return r.db.DBErr(err)
 	}
 
 	return nil

--- a/internal/demo/demo_respository.go
+++ b/internal/demo/demo_respository.go
@@ -26,7 +26,7 @@ func (r *demoRepository) ExpiredDemos(ctx context.Context, limit uint64) ([]doma
 		LeftJoin("report r on d.demo_id = r.demo_id").
 		Where("d.archive = false").
 		OrderBy("d.demo_id").
-		Offset(limit))
+		Limit(limit))
 	if errRow != nil {
 		return nil, r.db.DBErr(errRow)
 	}

--- a/internal/demo/demo_usecase.go
+++ b/internal/demo/demo_usecase.go
@@ -151,7 +151,7 @@ func (d demoUsecase) TruncateByCount(ctx context.Context, maxCount uint64) (int,
 	return count, size, nil
 }
 
-func (d demoUsecase) executeCleanup(ctx context.Context) {
+func (d demoUsecase) Cleanup(ctx context.Context) {
 	conf := d.config.Config()
 
 	if !conf.Demo.DemoCleanupEnabled {
@@ -188,7 +188,7 @@ func (d demoUsecase) Start(ctx context.Context) {
 	ticker := time.NewTicker(time.Hour)
 	tickerOrphans := time.NewTicker(time.Hour * 24)
 
-	d.executeCleanup(ctx)
+	d.Cleanup(ctx)
 
 	if err := d.RemoveOrphans(ctx); err != nil {
 		slog.Error("Failed to execute orphans", log.ErrAttr(err))
@@ -199,7 +199,7 @@ func (d demoUsecase) Start(ctx context.Context) {
 		case <-ticker.C:
 			d.cleanupChan <- true
 		case <-d.cleanupChan:
-			d.executeCleanup(ctx)
+			d.Cleanup(ctx)
 		case <-tickerOrphans.C:
 			if err := d.RemoveOrphans(ctx); err != nil {
 				slog.Error("Failed to execute orphans", log.ErrAttr(err))

--- a/internal/domain/asset.go
+++ b/internal/domain/asset.go
@@ -25,12 +25,14 @@ type AssetRepository interface {
 	Get(ctx context.Context, uuid uuid.UUID) (Asset, io.ReadSeeker, error)
 	Put(ctx context.Context, asset Asset, body io.ReadSeeker) (Asset, error)
 	Delete(ctx context.Context, uuid uuid.UUID) (int64, error)
+	GenAssetPath(hash string) (string, error)
 }
 
 type AssetUsecase interface {
 	Create(ctx context.Context, author steamid.SteamID, bucket Bucket, fileName string, content io.ReadSeeker) (Asset, error)
 	Get(ctx context.Context, assetID uuid.UUID) (Asset, io.ReadSeeker, error)
 	Delete(ctx context.Context, assetID uuid.UUID) (int64, error)
+	GenAssetPath(hash string) (string, error)
 }
 
 type UserUploadedFile struct {

--- a/internal/domain/demo.go
+++ b/internal/domain/demo.go
@@ -17,6 +17,7 @@ type DemoUsecase interface {
 	GetDemos(ctx context.Context) ([]DemoFile, error)
 	CreateFromAsset(ctx context.Context, asset Asset, serverID int) (*DemoFile, error)
 	TriggerCleanup()
+	Cleanup(ctx context.Context)
 }
 
 type DemoRepository interface {

--- a/internal/domain/demo.go
+++ b/internal/domain/demo.go
@@ -25,6 +25,7 @@ type DemoRepository interface {
 	GetDemoByName(ctx context.Context, demoName string, demoFile *DemoFile) error
 	GetDemos(ctx context.Context) ([]DemoFile, error)
 	SaveDemo(ctx context.Context, demoFile *DemoFile) error
+	Delete(ctx context.Context, demoID int64) error
 }
 
 type DemoPlayerStats struct {

--- a/internal/test/demos_test.go
+++ b/internal/test/demos_test.go
@@ -1,0 +1,43 @@
+package test_test
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"testing"
+
+	"github.com/leighmacdonald/gbans/internal/demo"
+	"github.com/leighmacdonald/gbans/internal/domain"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDemosCleanup(t *testing.T) {
+	ctx := context.Background()
+	fetcher := demo.NewFetcher(tempDB, configUC, serversUC, assetUC, demoUC)
+	go demoUC.Start(ctx)
+
+	for demoNum := range 10 {
+		content := make([]byte, 100000)
+		_, err := rand.Read(content)
+		require.NoError(t, err)
+
+		require.NoError(t, fetcher.OnDemoReceived(ctx, demo.UploadedDemo{
+			Name:    fmt.Sprintf("2023111%d-063943-koth_harvest_final.dem", demoNum),
+			Server:  testServer,
+			Content: content,
+		}))
+	}
+
+	conf := configUC.Config()
+	conf.Demo.DemoCleanupEnabled = true
+	conf.Demo.DemoCleanupStrategy = domain.DemoStrategyCount
+	conf.Demo.DemoCountLimit = 5
+
+	require.NoError(t, configUC.Write(ctx, conf))
+
+	demoUC.TriggerCleanup()
+
+	allDemos, err := demoUC.GetDemos(ctx)
+	require.NoError(t, err)
+	require.Len(t, len(allDemos), 5)
+}

--- a/internal/test/main_test.go
+++ b/internal/test/main_test.go
@@ -69,6 +69,7 @@ var (
 	banNetUC       domain.BanNetUsecase
 	assetUC        domain.AssetUsecase
 	chatUC         domain.ChatUsecase
+	demoRepository domain.DemoRepository
 	demoUC         domain.DemoUsecase
 	discordUC      domain.DiscordUsecase
 	forumUC        domain.ForumUsecase
@@ -141,7 +142,8 @@ func TestMain(m *testing.M) {
 	stateUC = state.NewStateUsecase(eventBroadcaster, state.NewStateRepository(state.NewCollector(serversUC)), configUC, serversUC)
 
 	networkUC = network.NewNetworkUsecase(eventBroadcaster, network.NewNetworkRepository(databaseConn), personUC, configUC)
-	demoUC = demo.NewDemoUsecase("demos", demo.NewDemoRepository(databaseConn), assetUC, configUC, serversUC)
+	demoRepository = demo.NewDemoRepository(databaseConn)
+	demoUC = demo.NewDemoUsecase("demos", demoRepository, assetUC, configUC, serversUC)
 	reportUC = report.NewReportUsecase(report.NewReportRepository(databaseConn), discordUC, configUC, personUC, demoUC)
 	banSteamUC = ban.NewBanSteamUsecase(ban.NewBanSteamRepository(databaseConn, personUC, networkUC), personUC, configUC, discordUC, reportUC, stateUC)
 	authUC = auth.NewAuthUsecase(authRepo, configUC, personUC, banSteamUC, serversUC)

--- a/internal/test/main_test.go
+++ b/internal/test/main_test.go
@@ -53,6 +53,7 @@ import (
 
 var (
 	dbContainer    *postgresContainer
+	tempDB         database.Database
 	testServer     domain.Server
 	testBan        domain.BannedSteamPerson
 	testTarget     domain.Person
@@ -178,6 +179,8 @@ func TestMain(m *testing.M) {
 
 	testServer = server
 
+	getOwner()
+
 	mod := getModerator()
 	target := getUser()
 
@@ -203,6 +206,7 @@ func TestMain(m *testing.M) {
 
 	testBan = bannedPerson
 	testTarget = target
+	tempDB = databaseConn
 
 	m.Run()
 }


### PR DESCRIPTION
- Add a check to cleanup orphaned demos (demos which do not exist on disk anymore despite a database entry)
- Add explicit call to delete demo since the FK cascade does not seem to function correctly. Issue still TBD, but this works as a temp fix.
- Fix query for querying expired demos.