### PR TITLE
Add support for internal address

### DIFF
--- a/frontend/src/api/server.ts
+++ b/frontend/src/api/server.ts
@@ -62,6 +62,7 @@ export interface Server extends TimeStamped {
     enable_stats: boolean;
     log_secret: number;
     token_created_on: Date;
+    address_internal: string;
 }
 
 export interface Location {
@@ -92,6 +93,7 @@ export interface SaveServerOpts {
     is_enabled: boolean;
     enable_stats: boolean;
     log_secret: number;
+    address_internal: string;
 }
 
 export const apiCreateServer = async (opts: SaveServerOpts) =>

--- a/frontend/src/component/modal/ServerEditorModal.tsx
+++ b/frontend/src/component/modal/ServerEditorModal.tsx
@@ -17,6 +17,7 @@ type ServerEditValues = {
     short_name: string;
     name: string;
     address: string;
+    address_internal: string;
     port: string;
     password: string;
     rcon: string;
@@ -50,7 +51,8 @@ export const ServerEditorModal = NiceModal.create(({ server }: { server?: Server
                 reserved_slots: Number(values.reserved_slots),
                 is_enabled: values.is_enabled,
                 enable_stats: values.enabled_stats,
-                log_secret: Number(values.log_secret)
+                log_secret: Number(values.log_secret),
+                address_internal: values.address_internal
             };
             if (server?.server_id) {
                 modal.resolve(await apiSaveServer(server.server_id, opts));
@@ -80,7 +82,8 @@ export const ServerEditorModal = NiceModal.create(({ server }: { server?: Server
             reserved_slots: server ? String(server.reserved_slots) : '0',
             is_enabled: server ? server.is_enabled : true,
             enabled_stats: server ? server.enable_stats : true,
-            log_secret: server ? String(server.log_secret) : ''
+            log_secret: server ? String(server.log_secret) : '',
+            address_internal: server ? server.address_internal : ''
         }
     });
 
@@ -140,6 +143,17 @@ export const ServerEditorModal = NiceModal.create(({ server }: { server?: Server
                                 }}
                                 children={(props) => {
                                     return <TextFieldSimple {...props} label={'Port'} />;
+                                }}
+                            />
+                        </Grid>
+                        <Grid xs={8}>
+                            <Field
+                                name={'address_internal'}
+                                validators={{
+                                    onChange: z.string()
+                                }}
+                                children={(props) => {
+                                    return <TextFieldSimple {...props} label={'Address Internal'} />;
                                 }}
                             />
                         </Grid>

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -424,8 +424,7 @@ func serveCmd() *cobra.Command { //nolint:maintidx
 				}
 			}()
 
-			periodicJons := createPeriodicJobs()
-			queueClient, errClient := queue.Client(dbConn.Pool(), workers, periodicJons)
+			queueClient, errClient := queue.Client(dbConn.Pool(), workers, createPeriodicJobs())
 			if errClient != nil {
 				slog.Error("Failed to setup job queue", log.ErrAttr(errClient))
 

--- a/internal/database/migrations/000104_add_address_internal.down.sql
+++ b/internal/database/migrations/000104_add_address_internal.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE config
+    DROP COLUMN IF EXISTS address_internal;
+
+COMMIT;

--- a/internal/database/migrations/000104_add_address_internal.up.sql
+++ b/internal/database/migrations/000104_add_address_internal.up.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE server
+    ADD COLUMN address_internal text not null default '';
+
+COMMIT;

--- a/internal/domain/server.go
+++ b/internal/domain/server.go
@@ -29,6 +29,7 @@ type RequestServerUpdate struct {
 	IsEnabled       bool    `json:"is_enabled"`
 	EnableStats     bool    `json:"enable_stats"`
 	LogSecret       int     `json:"log_secret"`
+	AddressInternal string  `json:"address_internal"`
 }
 
 type ServerInfoSafe struct {
@@ -89,6 +90,8 @@ type Server struct {
 	Name      string `json:"name"`
 	// Address is the ip of the server
 	Address string `json:"address"`
+	// Internal/VPN network. When defined its used for things like pulling demos over ssh.
+	AddressInternal string `json:"address_internal"`
 	// Port is the port of the server
 	Port int `json:"port"`
 	// RCON is the RCON password for the server
@@ -127,6 +130,14 @@ func (s Server) IP(ctx context.Context) (net.IP, error) {
 
 func (s Server) Addr() string {
 	return fmt.Sprintf("%s:%d", s.Address, s.Port)
+}
+
+func (s Server) AddrInternalOrDefault() string {
+	if s.AddressInternal != "" {
+		return s.AddressInternal
+	}
+
+	return s.Address
 }
 
 func (s Server) Slots(statusSlots int) int {

--- a/internal/network/scp.go
+++ b/internal/network/scp.go
@@ -64,12 +64,13 @@ func (f SCPExecer) Update(ctx context.Context) error {
 	mappedServers := map[string][]domain.Server{}
 
 	for _, server := range servers {
-		_, ok := mappedServers[server.Address]
+		actualAddr := server.AddrInternalOrDefault()
+		_, ok := mappedServers[actualAddr]
 		if !ok {
-			mappedServers[server.Address] = []domain.Server{}
+			mappedServers[actualAddr] = []domain.Server{}
 		}
 
-		mappedServers[server.Address] = append(mappedServers[server.Address], server)
+		mappedServers[actualAddr] = append(mappedServers[actualAddr], server)
 	}
 
 	sshConfig := f.config.Config().SSH
@@ -228,6 +229,8 @@ func (f SCPExecer) trustedHostKeyCallback(ctx context.Context) ssh.HostKeyCallba
 			if errSet := setKey(addr.String(), pubKeyString); errSet != nil {
 				return errSet
 			}
+
+			trustedPubKeyString = pubKeyString
 		}
 
 		if trustedPubKeyString != pubKeyString {

--- a/internal/servers/servers_repository.go
+++ b/internal/servers/servers_repository.go
@@ -26,7 +26,7 @@ func (r *serversRepository) GetServer(ctx context.Context, serverID int) (domain
 		Builder().
 		Select("server_id", "short_name", "name", "address", "port", "rcon", "password",
 			"token_created_on", "created_on", "updated_on", "reserved_slots", "is_enabled", "region", "cc",
-			"latitude", "longitude", "deleted", "log_secret", "enable_stats").
+			"latitude", "longitude", "deleted", "log_secret", "enable_stats", "address_internal").
 		From("server").
 		Where(sq.And{sq.Eq{"server_id": serverID}, sq.Eq{"deleted": false}}))
 	if rowErr != nil {
@@ -39,7 +39,7 @@ func (r *serversRepository) GetServer(ctx context.Context, serverID int) (domain
 		&server.Password, &tokenTime, &server.CreatedOn, &server.UpdatedOn,
 		&server.ReservedSlots, &server.IsEnabled, &server.Region, &server.CC,
 		&server.Latitude, &server.Longitude,
-		&server.Deleted, &server.LogSecret, &server.EnableStats); errScan != nil {
+		&server.Deleted, &server.LogSecret, &server.EnableStats, &server.AddressInternal); errScan != nil {
 		return server, r.db.DBErr(errScan)
 	}
 
@@ -101,7 +101,7 @@ func (r *serversRepository) GetServers(ctx context.Context, filter domain.Server
 		Builder().
 		Select("s.server_id", "s.short_name", "s.name", "s.address", "s.port", "s.rcon", "s.password",
 			"s.token_created_on", "s.created_on", "s.updated_on", "s.reserved_slots", "s.is_enabled", "s.region", "s.cc",
-			"s.latitude", "s.longitude", "s.deleted", "s.log_secret", "s.enable_stats").
+			"s.latitude", "s.longitude", "s.deleted", "s.log_secret", "s.enable_stats", "s.address_internal").
 		From("server s")
 
 	var constraints sq.And
@@ -118,7 +118,7 @@ func (r *serversRepository) GetServers(ctx context.Context, filter domain.Server
 		"s.": {
 			"server_id", "short_name", "name", "address", "port",
 			"token_created_on", "created_on", "updated_on", "reserved_slots", "is_enabled", "region", "cc",
-			"latitude", "longitude", "deleted", "enable_stats",
+			"latitude", "longitude", "deleted", "enable_stats", "address_internal",
 		},
 	}, "short_name")
 
@@ -143,7 +143,7 @@ func (r *serversRepository) GetServers(ctx context.Context, filter domain.Server
 			Scan(&server.ServerID, &server.ShortName, &server.Name, &server.Address, &server.Port, &server.RCON,
 				&server.Password, &tokenDate, &server.CreatedOn, &server.UpdatedOn, &server.ReservedSlots,
 				&server.IsEnabled, &server.Region, &server.CC, &server.Latitude, &server.Longitude,
-				&server.Deleted, &server.LogSecret, &server.EnableStats); errScan != nil {
+				&server.Deleted, &server.LogSecret, &server.EnableStats, &server.AddressInternal); errScan != nil {
 			return nil, 0, errors.Join(errScan, domain.ErrScanResult)
 		}
 
@@ -184,14 +184,12 @@ func (r *serversRepository) GetServerByName(ctx context.Context, serverName stri
 		Builder().
 		Select("server_id", "short_name", "name", "address", "port", "rcon", "password",
 			"token_created_on", "created_on", "updated_on", "reserved_slots", "is_enabled", "region", "cc",
-			"latitude", "longitude", "deleted", "log_secret", "enable_stats").
+			"latitude", "longitude", "deleted", "log_secret", "enable_stats", "address_internal").
 		From("server").
 		Where(and))
 	if errRow != nil {
 		return r.db.DBErr(errRow)
 	}
-
-	var tokenTime *time.Time
 
 	if err := row.Scan(
 		&server.ServerID,
@@ -202,12 +200,8 @@ func (r *serversRepository) GetServerByName(ctx context.Context, serverName stri
 		&server.RCON,
 		&server.Password, &server.TokenCreatedOn, &server.CreatedOn, &server.UpdatedOn, &server.ReservedSlots,
 		&server.IsEnabled, &server.Region, &server.CC, &server.Latitude, &server.Longitude,
-		&server.Deleted, &server.LogSecret, &server.EnableStats); err != nil {
+		&server.Deleted, &server.LogSecret, &server.EnableStats, &server.AddressInternal); err != nil {
 		return r.db.DBErr(err)
-	}
-
-	if tokenTime != nil {
-		server.TokenCreatedOn = *tokenTime
 	}
 
 	return nil
@@ -227,7 +221,7 @@ func (r *serversRepository) GetServerByPassword(ctx context.Context, serverPassw
 		Builder().
 		Select("server_id", "short_name", "name", "address", "port", "rcon", "password",
 			"token_created_on", "created_on", "updated_on", "reserved_slots", "is_enabled", "region", "cc",
-			"latitude", "longitude", "deleted", "log_secret", "enable_stats").
+			"latitude", "longitude", "deleted", "log_secret", "enable_stats", "address_internal").
 		From("server").
 		Where(and))
 	if errRow != nil {
@@ -239,7 +233,7 @@ func (r *serversRepository) GetServerByPassword(ctx context.Context, serverPassw
 	if err := row.Scan(&server.ServerID, &server.ShortName, &server.Name, &server.Address, &server.Port,
 		&server.RCON, &server.Password, &tokenTime, &server.CreatedOn, &server.UpdatedOn,
 		&server.ReservedSlots, &server.IsEnabled, &server.Region, &server.CC, &server.Latitude,
-		&server.Longitude, &server.Deleted, &server.LogSecret, &server.EnableStats); err != nil {
+		&server.Longitude, &server.Deleted, &server.LogSecret, &server.EnableStats, &server.AddressInternal); err != nil {
 		return r.db.DBErr(err)
 	}
 
@@ -264,14 +258,14 @@ func (r *serversRepository) insertServer(ctx context.Context, server *domain.Ser
 		INSERT INTO server (
 		    short_name, name, address, port, rcon, token_created_on, 
 		    reserved_slots, created_on, updated_on, password, is_enabled, region, cc, latitude, longitude, 
-			deleted, log_secret, enable_stats) 
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
+			deleted, log_secret, enable_stats, address_internal) 
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)
 		RETURNING server_id;`
 
 	err := r.db.QueryRow(ctx, nil, query, server.ShortName, server.Name, server.Address, server.Port,
 		server.RCON, server.TokenCreatedOn, server.ReservedSlots, server.CreatedOn, server.UpdatedOn,
 		server.Password, server.IsEnabled, server.Region, server.CC,
-		server.Latitude, server.Longitude, server.Deleted, &server.LogSecret, &server.EnableStats).
+		server.Latitude, server.Longitude, server.Deleted, &server.LogSecret, &server.EnableStats, &server.AddressInternal).
 		Scan(&server.ServerID)
 	if err != nil {
 		return r.db.DBErr(err)
@@ -303,5 +297,6 @@ func (r *serversRepository) updateServer(ctx context.Context, server *domain.Ser
 		Set("longitude", server.Longitude).
 		Set("log_secret", server.LogSecret).
 		Set("enable_stats", server.EnableStats).
+		Set("address_internal", server.AddressInternal).
 		Where(sq.Eq{"server_id": server.ServerID})))
 }

--- a/internal/servers/servers_usecase.go
+++ b/internal/servers/servers_usecase.go
@@ -7,10 +7,16 @@ import (
 	"github.com/leighmacdonald/gbans/internal/domain"
 )
 
+func NewServersUsecase(repository domain.ServersRepository) domain.ServersUsecase {
+	return &serversUsecase{repository: repository}
+}
+
 type serversUsecase struct {
 	repository domain.ServersRepository
 }
 
+// Delete performs a soft delete of the server. We use soft deleted because we dont wand to delete all the relationships
+// that rely on this suchs a stats.
 func (s *serversUsecase) Delete(ctx context.Context, serverID int) error {
 	if serverID <= 0 {
 		return domain.ErrInvalidParameter
@@ -24,10 +30,6 @@ func (s *serversUsecase) Delete(ctx context.Context, serverID int) error {
 	server.Deleted = true
 
 	return s.repository.SaveServer(ctx, &server)
-}
-
-func NewServersUsecase(repository domain.ServersRepository) domain.ServersUsecase {
-	return &serversUsecase{repository: repository}
 }
 
 func (s *serversUsecase) Server(ctx context.Context, serverID int) (domain.Server, error) {
@@ -82,6 +84,7 @@ func (s *serversUsecase) Save(ctx context.Context, req domain.RequestServerUpdat
 	server.IsEnabled = req.IsEnabled
 	server.LogSecret = req.LogSecret
 	server.EnableStats = req.EnableStats
+	server.AddressInternal = req.AddressInternal
 
 	if err := s.repository.SaveServer(ctx, &server); err != nil {
 		return domain.Server{}, err

--- a/internal/state/collector.go
+++ b/internal/state/collector.go
@@ -21,7 +21,7 @@ import (
 
 var (
 	ErrRCONCommand      = errors.New("failed to execute rcon command")
-	ErrFailedToDialRCON = errors.New("failed to connect to conf")
+	ErrFailedToDialRCON = errors.New("failed to dial rcon")
 )
 
 type Collector struct {

--- a/internal/state/state_usecase.go
+++ b/internal/state/state_usecase.go
@@ -314,6 +314,10 @@ func (s *stateUsecase) Broadcast(ctx context.Context, serverIDs []int, cmd strin
 
 			resp, errExec := s.state.ExecRaw(egCtx, serverConf.Addr(), serverConf.RconPassword, cmd)
 			if errExec != nil {
+				if errors.Is(errExec, context.Canceled) {
+					return nil
+				}
+
 				slog.Error("Failed to exec server command", slog.String("name", serverConf.DefaultHostname),
 					slog.Int("server_id", sid), log.ErrAttr(errExec))
 


### PR DESCRIPTION
Addes a address_internal field to server struct/db. When not empty, will be used in place of the standard address. This is designed for cases where ssh, and potentially over services in the future, is only exposed over the internal/vpn interface.