### PR TITLE
Fix websockets connection on https site

### DIFF
--- a/frontend/src/api/playerqueue.ts
+++ b/frontend/src/api/playerqueue.ts
@@ -103,7 +103,7 @@ export type ChatStatus = 'readwrite' | 'readonly' | 'noaccess';
 export const websocketURL = () => {
     let protocol = 'ws';
     if (location.protocol === 'https:') {
-        protocol = 'wss:';
+        protocol = 'wss';
     }
     return `${protocol}://${location.host}/ws`;
 };


### PR DESCRIPTION
This currently forms an invalid url that starts with `wss:://`  