### PR TITLE
Validate server addresses for UDP log messages. Fixes #605

### DIFF
--- a/internal/domain/server.go
+++ b/internal/domain/server.go
@@ -130,6 +130,21 @@ func (s Server) IP(ctx context.Context) (net.IP, error) {
 	return ips[0], nil
 }
 
+func (s Server) IPInternal(ctx context.Context) (net.IP, error) {
+	parsedIP := net.ParseIP(s.AddressInternal)
+	if parsedIP != nil {
+		// We already have an ip
+		return parsedIP, nil
+	}
+	// TODO proper timeout for ctx
+	ips, errResolve := net.DefaultResolver.LookupIP(ctx, "ip4", s.Address)
+	if errResolve != nil || len(ips) == 0 {
+		return nil, errors.Join(errResolve, ErrResolveIP)
+	}
+
+	return ips[0], nil
+}
+
 func (s Server) Addr() string {
 	return fmt.Sprintf("%s:%d", s.Address, s.Port)
 }


### PR DESCRIPTION
Manually tested that `nc -u 0.0.0.0 27715` fails from an IP that is not listed on any servers and chat message logging still works from an IP that is associated with a server.

While it's a security improvement, this is a breaking change, so I can add a setting for it if you'd like.