### PR TITLE
Enable Cookie Fingerprinting

### DIFF
--- a/internal/auth/auth_http.go
+++ b/internal/auth/auth_http.go
@@ -27,6 +27,7 @@ func safeRedirectURL(rawURL string) string {
 
 type TokenGenerator interface {
 	MakeUserToken(id person.BaseUser) (string, string, error)
+	ValidateUserToken(tokenStr string, fingerprint string) (steamid.SteamID, error)
 }
 
 type authHandler struct {
@@ -50,6 +51,7 @@ func NewAuthHandler(mux *http.ServeMux, auth *Authentication, config *config.Con
 	}
 
 	mux.HandleFunc("GET /auth/callback", handler.onSteamOIDCCallback())
+	mux.HandleFunc("GET /api/auth/logout", handler.onAPILogout())
 }
 
 func (h *authHandler) onSteamOIDCCallback() http.HandlerFunc {
@@ -163,6 +165,66 @@ func (h *authHandler) onSteamOIDCCallback() http.HandlerFunc {
 			slog.String("sid64", sid.String()),
 			slog.String("name", fetchedPerson.GetName()),
 			slog.Int("permission_level", int(fetchedPerson.PermissionLevel)))
+	}
+}
+
+func (h *authHandler) onAPILogout() http.HandlerFunc {
+	conf := h.config.Config()
+
+	return func(res http.ResponseWriter, req *http.Request) {
+		var sid steamid.SteamID
+
+		fingerprint, errCookie := req.Cookie(FingerprintCookieName)
+		if errCookie == nil {
+			parsedExternal, errExternal := url.Parse(conf.ExternalURL)
+			if errExternal == nil {
+				http.SetCookie(res, &http.Cookie{ //nolint:gosec
+					Name:     FingerprintCookieName,
+					Value:    "",
+					MaxAge:   -1,
+					Path:     "/connect",
+					Domain:   parsedExternal.Hostname(),
+					Secure:   strings.HasPrefix(strings.ToLower(conf.ExternalURL), "https://"),
+					HttpOnly: true,
+					SameSite: http.SameSiteStrictMode,
+				})
+			}
+		}
+
+		authHeader := req.Header.Get("Authorization")
+		if authHeader != "" && strings.HasPrefix(authHeader, "Bearer ") && errCookie == nil {
+			token := strings.TrimPrefix(authHeader, "Bearer ")
+
+			validatedSID, errValidation := h.tokenGenerator.ValidateUserToken(token, fingerprint.Value)
+			if errValidation == nil {
+				sid = validatedSID
+			}
+		}
+
+		httphelper.RespondJSON(res, http.StatusOK, map[string]string{})
+
+		if sid.Valid() {
+			go func(steamID steamid.SteamID) {
+				sentry.AddBreadcrumb(&sentry.Breadcrumb{
+					Category: "auth",
+					Message:  "User logged out " + steamID.String(),
+					Level:    sentry.LevelWarning,
+				})
+
+				sentry.ConfigureScope(func(scope *sentry.Scope) {
+					scope.SetUser(sentry.User{})
+				})
+
+				player, errPerson := h.persons.GetOrCreatePersonBySteamID(req.Context(), steamID)
+				if errPerson != nil {
+					slog.Error("Failed to load user for logout notification", slog.String("error", errPerson.Error()))
+
+					return
+				}
+
+				h.notif.Send(notification.NewDiscord(conf.Discord.LogChannelID, logoutMessage(player)))
+			}(sid)
+		}
 	}
 }
 

--- a/internal/httphelper/errors.go
+++ b/internal/httphelper/errors.go
@@ -8,6 +8,8 @@ import (
 )
 
 var (
+	ErrBadRequest         = errors.New("bad request")
+	ErrInternal           = errors.New("internal error")
 	ErrNotFound           = errors.New("entity not found")
 	ErrRequestPerform     = errors.New("could not perform http request")
 	ErrRequestInvalidCode = errors.New("invalid response code returned from request")

--- a/internal/rpc/auth.go
+++ b/internal/rpc/auth.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -28,8 +29,10 @@ const (
 )
 
 var (
-	ErrCreateToken = errors.New("failed to create new Access token")
-	ErrSignToken   = errors.New("failed create signed string")
+	ErrCreateToken           = errors.New("failed to create new Access token")
+	ErrSignToken             = errors.New("failed create signed string")
+	ErrFingerprintMismatch   = errors.New("fingerprint mismatch")
+	ErrInvalidSteamIDInToken = errors.New("invalid steamid in token")
 )
 
 // UserClaimProvider defines the required fields to extract user claims for JWT creation.
@@ -240,7 +243,7 @@ func (m *Middleware) serverClaimsFromRequest(req *http.Request) (*serverClaims, 
 }
 
 func (m *Middleware) userClaimsFromRequest(req *http.Request) (*userClaims, error) {
-	_, errFP := m.fingerprintFromRequest(req)
+	fingerprint, errFP := m.fingerprintFromRequest(req)
 	if errFP != nil {
 		return nil, errFP
 	}
@@ -269,19 +272,19 @@ func (m *Middleware) userClaimsFromRequest(req *http.Request) (*userClaims, erro
 		return nil, authn.Errorf("invalid token")
 	}
 
-	// if claims.Fingerprint != m.fingerprintHash(fingerprint) {
-	// 	slog.Error("Invalid cookie fingerprint, token rejected")
+	if claims.Fingerprint != fingerprintHash(fingerprint) {
+		slog.Error("Invalid cookie fingerprint, token rejected")
 
-	// 	return nil, authn.Errorf("invalid token")
-	// }
+		return nil, authn.Errorf("invalid token")
+	}
 
 	return &claims, nil
 }
 
-func (m *Middleware) fingerprintHash(fingerprint string) string {
-	hasher := sha256.New()
+func fingerprintHash(fingerprint string) string {
+	sum := sha256.Sum256([]byte(fingerprint))
 
-	return hex.EncodeToString(hasher.Sum([]byte(fingerprint)))
+	return hex.EncodeToString(sum[:])
 }
 
 func (m *Middleware) fingerprintFromRequest(req *http.Request) (string, error) {
@@ -335,7 +338,7 @@ func (m *Middleware) newUserToken(user UserClaimProvider, fingerPrint string, va
 	nowTime := time.Now()
 	sid := user.GetSteamID()
 	claims := userClaims{
-		Fingerprint: m.fingerprintHash(fingerPrint),
+		Fingerprint: fingerprintHash(fingerPrint),
 		RegisteredClaims: jwt.RegisteredClaims{
 			Issuer:    m.siteName,
 			Subject:   sid.String(),
@@ -381,4 +384,33 @@ func (m *Middleware) MakeUserToken(user person.BaseUser) (string, string, error)
 	// }
 
 	return accessToken, fingerprint, nil
+}
+
+// ValidateUserToken parses a JWT access token and validates it against the provided fingerprint.
+// Returns the SteamID from the token claims on success.
+func (m *Middleware) ValidateUserToken(tokenStr string, fingerprint string) (steamid.SteamID, error) {
+	claims := userClaims{}
+	tkn, err := jwt.ParseWithClaims(tokenStr, &claims, m.makeGetTokenKey())
+	if err != nil {
+		if errors.Is(err, jwt.ErrTokenExpired) {
+			return steamid.SteamID{}, errors.Join(err, ErrSignToken)
+		}
+
+		return steamid.SteamID{}, errors.Join(err, ErrSignToken)
+	}
+
+	if !tkn.Valid {
+		return steamid.SteamID{}, ErrSignToken
+	}
+
+	if claims.Fingerprint != fingerprintHash(fingerprint) {
+		return steamid.SteamID{}, ErrFingerprintMismatch
+	}
+
+	sid := steamid.New(claims.Subject)
+	if !sid.Valid() {
+		return steamid.SteamID{}, ErrInvalidSteamIDInToken
+	}
+
+	return sid, nil
 }


### PR DESCRIPTION
Now that connectrpc is in place, we can re-enable cookie fingerprint hash checks to prevent credential leaks from local storage.